### PR TITLE
fix(squad5): Align comments and docs with pt-BR guidelines

### DIFF
--- a/docs/schemas/question_import_schema.md
+++ b/docs/schemas/question_import_schema.md
@@ -1,0 +1,84 @@
+# Esquema JSON para Importação de Questões
+
+Este documento define o esquema JSON para importar questões para o `bancoq` (banco de questões). O esquema é baseado na struct `models.Question`.
+
+## Definição do Esquema
+
+A importação espera um array JSON de objetos de questão. Cada objeto de questão deve estar em conformidade com a seguinte estrutura:
+
+```json
+{
+  "id": "string (UUID recomendado, opcional, será gerado se ausente)",
+  "subject": "string (obrigatório, ex: \"Matemática\")",
+  "topic": "string (obrigatório, ex: \"Álgebra\")",
+  "difficulty": "string (obrigatório, ex: \"easy\", \"medium\", \"hard\" - manter em inglês para consistência de código)",
+  "question_text": "string (obrigatório, a questão em si)",
+  "answer_options": [
+    "string (para multiple_choice, true_false)"
+  ],
+  "correct_answers": [
+    "string (obrigatório, uma ou mais respostas corretas)"
+  ],
+  "question_type": "string (obrigatório, ex: \"multiple_choice\", \"true_false\", \"essay\", \"short_answer\" - manter em inglês para consistência de código)",
+  "source": "string (opcional, ex: \"Livro Didático A, Capítulo 5\")",
+  "tags": [
+    "string (opcional, para categorização)"
+  ],
+  "created_at": "string (datetime ISO 8601, opcional, padrão para hora da importação)",
+  "last_used_at": "string (datetime ISO 8601, opcional)",
+  "author": "string (opcional, quem criou/adicionou esta questão)"
+}
+```
+
+### Descrições dos Campos:
+
+*   **`id`**: (String, Opcional) Um identificador único para a questão. Se não fornecido, o sistema deve gerar um (ex: UUID v4).
+*   **`subject`**: (String, Obrigatório) A matéria principal da questão (ex: "História", "Matemática"). O valor deve ser em português.
+*   **`topic`**: (String, Obrigatório) Um tópico mais específico dentro da matéria (ex: "Revolução Francesa", "Equações de Primeiro Grau"). O valor deve ser em português.
+*   **`difficulty`**: (String, Obrigatório) O nível de dificuldade. Valores sugeridos: `"easy"`, `"medium"`, `"hard"`. Estes valores são chaves internas e devem permanecer em inglês; a UI se encarregará da tradução para o usuário.
+*   **`question_text`**: (String, Obrigatório) O texto completo da questão. O valor deve ser em português.
+*   **`answer_options`**: (Array de Strings, Opcional) Para tipos de questão como `"multiple_choice"` ou `"true_false"`, este array contém as escolhas possíveis. Para `"essay"` ou `"short_answer"`, pode ser omitido ou ser um array vazio. Os valores devem ser em português.
+*   **`correct_answers`**: (Array de Strings, Obrigatório) Um array contendo a(s) resposta(s) correta(s). Para múltipla escolha, seria o texto da(s) opção(ões) correta(s). Para verdadeiro/falso, seria `"Verdadeiro"` ou `"Falso"`. Para dissertativa/resposta curta, poderia ser uma resposta modelo ou pontos chave. Os valores devem ser em português.
+*   **`question_type`**: (String, Obrigatório) O tipo de questão. Valores sugeridos: `"multiple_choice"`, `"true_false"`, `"essay"`, `"short_answer"`. Estes valores são chaves internas e devem permanecer em inglês; a UI se encarregará da tradução para o usuário.
+*   **`source`**: (String, Opcional) A origem da questão (ex: "Livro Didático X, pg. 52", "Prova Anterior 2022"). O valor deve ser em português.
+*   **`tags`**: (Array de Strings, Opcional) Tags para categorização e busca adicionais (ex: `["ENEM", "conceitual"]`). Os valores podem ser em português.
+*   **`created_at`**: (String, Opcional) A data e hora em que a questão foi criada, em formato ISO 8601 (ex: `"2023-10-26T10:00:00Z"`). Padrão para a hora da importação se não fornecido.
+*   **`last_used_at`**: (String, Opcional) A data e hora em que a questão foi usada pela última vez, em formato ISO 8601.
+*   **`author`**: (String, Opcional) A pessoa que criou ou adicionou a questão.
+
+## Exemplo de Conteúdo de Arquivo JSON para Importação
+
+```json
+[
+  {
+    "subject": "Matemática",
+    "topic": "Geometria",
+    "difficulty": "medium",
+    "question_text": "Qual é a fórmula para a área de um círculo?",
+    "answer_options": ["A = πr²", "A = 2πr", "A = πd", "A = r²"],
+    "correct_answers": ["A = πr²"],
+    "question_type": "multiple_choice",
+    "tags": ["fórmula", "círculo"],
+    "author": "Prof. Alan Turing"
+  },
+  {
+    "subject": "História",
+    "topic": "Segunda Guerra Mundial",
+    "difficulty": "hard",
+    "question_text": "Descreva os principais fatores que levaram ao início da Segunda Guerra Mundial.",
+    "correct_answers": ["Expansionismo alemão, falha da Liga das Nações, Tratado de Versalhes, crise de 1929."],
+    "question_type": "essay",
+    "source": "Documentário XYZ",
+    "created_at": "2022-05-10T14:30:00Z"
+  },
+  {
+    "subject": "Ciências",
+    "topic": "Biologia Celular",
+    "difficulty": "easy",
+    "question_text": "A mitocôndria é responsável pela respiração celular. (Verdadeiro/Falso)",
+    "answer_options": ["Verdadeiro", "Falso"],
+    "correct_answers": ["Verdadeiro"],
+    "question_type": "true_false"
+  }
+]
+```

--- a/docs/specifications/bancoq_command_spec.md
+++ b/docs/specifications/bancoq_command_spec.md
@@ -1,0 +1,149 @@
+# Especificação Técnica: Comando `bancoq`
+
+Este documento detalha o comando `bancoq` (Banco de Questões) da Vickgenda CLI, responsável por gerenciar a coleção de questões pedagógicas do professor.
+
+## 1. Visão Geral do Comando
+
+O comando `bancoq` permite aos usuários adicionar, listar, visualizar, editar, pesquisar, remover e importar questões para o banco de dados local.
+
+**Nome do comando:** `vickgenda bancoq`
+
+## 2. Estrutura de Dados de Referência
+
+Este comando opera sobre a struct `models.Question` (definida em `internal/models/question.go`) e utiliza o esquema de importação JSON (definido em `docs/schemas/question_import_schema.md`).
+
+## 3. Subcomandos
+
+### 3.1. `bancoq add`
+
+*   **Propósito:** Adicionar uma nova questão interativamente ou via flags.
+*   **Uso:**
+    *   `vickgenda bancoq add [flags]`
+*   **Flags (para modo não interativo):**
+    *   `--subject "Matemática"` (Obrigatório)
+    *   `--topic "Álgebra"` (Obrigatório)
+    *   `--difficulty "medium"` (Obrigatório: easy, medium, hard)
+    *   `--type "multiple_choice"` (Obrigatório: multiple_choice, true_false, essay, short_answer)
+    *   `--question "Qual a fórmula de Bhaskara?"` (Obrigatório)
+    *   `--option "Opção A"` (Múltiplo, para `multiple_choice`, `true_false`)
+    *   `--answer "Opção A"` (Múltiplo, respostas corretas)
+    *   `--source "Livro X"` (Opcional)
+    *   `--tag "ENEM"` (Múltiplo, opcional)
+    *   `--author "Prof. Y"` (Opcional)
+*   **Comportamento Interativo:**
+    *   Se nenhuma flag obrigatória for fornecida, o comando entra em modo interativo, solicitando cada campo da questão passo a passo.
+    *   As opções de múltipla escolha e respostas corretas são solicitadas até que o usuário indique que terminou.
+*   **Saída:**
+    *   Sucesso: "Questão adicionada com ID: [ID_DA_QUESTAO]"
+    *   Erro: Mensagens claras sobre campos faltantes ou inválidos (em pt-BR).
+*   **Interação com BD:** Cria um novo registro `Question` na base de dados.
+
+### 3.2. `bancoq list`
+
+*   **Propósito:** Listar as questões existentes com filtros opcionais.
+*   **Uso:**
+    *   `vickgenda bancoq list [flags]`
+*   **Flags:**
+    *   `--subject "Matemática"` (Opcional)
+    *   `--topic "Álgebra"` (Opcional)
+    *   `--difficulty "medium"` (Opcional)
+    *   `--type "multiple_choice"` (Opcional)
+    *   `--tag "ENEM"` (Opcional)
+    *   `--author "Prof. Y"` (Opcional)
+    *   `--limit 20` (Opcional, default 20)
+    *   `--page 1` (Opcional, default 1, para paginação)
+    *   `--sort-by "created_at"` (Opcional, default: created_at. Outras opções: subject, topic, difficulty, last_used_at)
+    *   `--order "desc"` (Opcional, default: desc. Opções: asc, desc)
+*   **Saída:**
+    *   Tabela formatada com colunas: ID (curto), Assunto, Tópico, Tipo, Dificuldade, Início da Questão.
+    *   Se nenhuma questão encontrada: "Nenhuma questão encontrada com os filtros aplicados."
+*   **Interação com BD:** Lê registros `Question` da base de dados.
+
+### 3.3. `bancoq view <id>`
+
+*   **Propósito:** Visualizar todos os detalhes de uma questão específica.
+*   **Uso:**
+    *   `vickgenda bancoq view <ID_DA_QUESTAO>`
+*   **Argumentos:**
+    *   `<ID_DA_QUESTAO>` (Obrigatório): O ID completo da questão.
+*   **Saída:**
+    *   Exibição formatada de todos os campos da questão, incluindo texto completo, opções (se houver) e respostas.
+    *   Se não encontrada: "Questão com ID [ID_DA_QUESTAO] não encontrada."
+*   **Interação com BD:** Lê um registro `Question` específico.
+
+### 3.4. `bancoq edit <id>`
+
+*   **Propósito:** Editar uma questão existente interativamente.
+*   **Uso:**
+    *   `vickgenda bancoq edit <ID_DA_QUESTAO>`
+*   **Argumentos:**
+    *   `<ID_DA_QUESTAO>` (Obrigatório).
+*   **Comportamento:**
+    *   Carrega os dados da questão.
+    *   Permite ao usuário modificar cada campo interativamente, mostrando o valor atual.
+    *   O usuário pode pular campos que não deseja alterar.
+*   **Saída:**
+    *   Sucesso: "Questão [ID_DA_QUESTAO] atualizada com sucesso."
+    *   Erro: "Questão com ID [ID_DA_QUESTAO] não encontrada."
+*   **Interação com BD:** Atualiza um registro `Question` existente.
+
+### 3.5. `bancoq delete <id>`
+
+*   **Propósito:** Remover uma questão do banco de dados.
+*   **Uso:**
+    *   `vickgenda bancoq delete <ID_DA_QUESTAO> [--force]`
+*   **Argumentos:**
+    *   `<ID_DA_QUESTAO>` (Obrigatório).
+*   **Flags:**
+    *   `--force` ou `-f`: Pula a confirmação.
+*   **Comportamento:**
+    *   Solicita confirmação antes de deletar, a menos que `--force` seja usado.
+*   **Saída:**
+    *   Sucesso: "Questão [ID_DA_QUESTAO] removida com sucesso."
+    *   Cancelado: "Remoção cancelada pelo usuário."
+    *   Erro: "Questão com ID [ID_DA_QUESTAO] não encontrada."
+*   **Interação com BD:** Remove um registro `Question`.
+
+### 3.6. `bancoq import <filepath>`
+
+*   **Propósito:** Importar questões de um arquivo JSON.
+*   **Uso:**
+    *   `vickgenda bancoq import <CAMINHO_DO_ARQUIVO_JSON>`
+*   **Argumentos:**
+    *   `<CAMINHO_DO_ARQUIVO_JSON>` (Obrigatório): Caminho para o arquivo JSON contendo um array de questões (ver `docs/schemas/question_import_schema.md`).
+*   **Comportamento:**
+    *   Processa o arquivo JSON.
+    *   Para cada questão no arquivo:
+        *   Valida os dados contra o schema.
+        *   Se um ID for fornecido e já existir, pode pular, atualizar (requer flag --update-existing) ou falhar (default).
+        *   Se nenhum ID for fornecido, gera um novo.
+        *   Adiciona a questão ao banco de dados.
+*   **Flags:**
+    *   `--on-conflict "skip|update|fail"` (Default: `fail`): O que fazer se uma questão com o mesmo ID já existir. `update` necessitaria de lógica adicional para mesclar.
+    *   `--dry-run`: Simula a importação sem gravar no banco, apenas reportando o que seria feito.
+*   **Saída:**
+    *   Progresso da importação (e.g., "Importando questão X de Y...").
+    *   Resumo: "Importação concluída. X questões importadas com sucesso. Y questões falharam."
+    *   Relatório de erros detalhado para questões que falharam na importação (e.g., "Erro na questão Z: Campo 'subject' obrigatório não fornecido.").
+*   **Interação com BD:** Cria múltiplos registros `Question`.
+
+### 3.7. `bancoq search "<query>"`
+
+*   **Propósito:** Procurar questões por palavras-chave no texto da questão, assunto, tópico ou tags.
+*   **Uso:**
+    *   `vickgenda bancoq search "<TERMO_DE_BUSCA>" [flags]`
+*   **Argumentos:**
+    *   `<TERMO_DE_BUSCA>` (Obrigatório).
+*   **Flags:**
+    *   Mesmas flags de filtro e paginação de `bancoq list` (e.g., `--subject`, `--limit`, etc.).
+    *   `--field "all|text|subject|topic|tags"` (Default: `text`): Em quais campos procurar. `all` busca em todos os campos textuais relevantes.
+*   **Saída:**
+    *   Similar a `bancoq list`, mostrando as questões que correspondem à busca.
+*   **Interação com BD:** Lê registros `Question` usando consultas de pesquisa (e.g., LIKE ou Full-Text Search se o SQLite estiver configurado para isso).
+
+## 4. Considerações Gerais
+
+*   **IDs:** IDs de questões devem ser únicos (preferencialmente UUIDs). IDs curtos podem ser usados para exibição e entrada do usuário onde não houver ambiguidade, mas o sistema deve sempre resolver para o ID completo internamente.
+*   **Validação:** Validação robusta de entradas e dados importados.
+*   **Feedback ao Usuário:** Mensagens claras e úteis em Português do Brasil (pt-BR).
+*   **Ajuda:** Cada subcomando deve ter uma tela de ajuda detalhada (`--help`).

--- a/docs/specifications/prova_command_spec.md
+++ b/docs/specifications/prova_command_spec.md
@@ -1,0 +1,131 @@
+# Especificação Técnica: Comando `prova`
+
+Este documento detalha o comando `prova` da Vickgenda CLI, responsável por gerar e gerenciar provas (avaliações) a partir das questões armazenadas no `bancoq` (Banco de Questões).
+
+## 1. Visão Geral do Comando
+
+O comando `prova` permite aos usuários gerar novas provas selecionando questões do banco, listar provas existentes, visualizar detalhes de uma prova, e potencialmente exportá-las.
+
+**Nome do comando:** `vickgenda prova`
+
+## 2. Estrutura de Dados de Referência
+
+*   Este comando utiliza as questões (`models.Question`) do `bancoq`.
+*   Será necessário definir uma nova struct, por exemplo `models.Test` (ou `models.Prova`), para armazenar informações sobre a prova gerada. Esta struct conteria:
+    *   `ID`: Identificador único da prova.
+    *   `Title`: Título da prova (e.g., "Prova Mensal de Matemática - Turma A").
+    *   `Subject`: Disciplina principal da prova.
+    *   `CreatedAt`: Data de criação.
+    *   `Instructions`: Instruções gerais para a prova.
+    *   `QuestionIDs`: Uma lista ordenada dos IDs das questões incluídas na prova.
+    *   `LayoutOptions`: Opções de formatação (e.g., número de colunas, cabeçalho).
+    *   `RandomizationSeed`: Se a ordem das questões ou alternativas foi randomizada, guardar a semente.
+
+## 3. Subcomandos
+
+### 3.1. `prova generate`
+
+*   **Propósito:** Gerar uma nova prova interativamente ou via flags, selecionando questões do `bancoq`.
+*   **Uso:**
+    *   `vickgenda prova generate [flags]`
+*   **Flags:**
+    *   `--title "Prova Bimestral de História"` (Obrigatório)
+    *   `--subject "História"` (Obrigatório, para filtrar questões)
+    *   `--topic "Revolução Francesa"` (Múltiplo, opcional, para filtrar questões)
+    *   `--difficulty "medium"` (Múltiplo, opcional: easy, medium, hard, para filtrar questões)
+    *   `--type "multiple_choice"` (Múltiplo, opcional, para filtrar tipos de questão)
+    *   `--tag " ENEM"` (Múltiplo, opcional, para filtrar por tags)
+    *   `--num-questions 10` (Opcional, número total de questões desejadas)
+    *   `--num-easy 3` (Opcional, número específico de questões fáceis)
+    *   `--num-medium 4` (Opcional, número específico de questões médias)
+    *   `--num-hard 3` (Opcional, número específico de questões difíceis)
+    *   `--allow-duplicates false` (Opcional, default: false. Permite usar a mesma questão mais de uma vez na prova)
+    *   `--randomize-order true` (Opcional, default: false. Randomiza a ordem das questões na prova)
+    *   `--output-file "prova_historia.txt"` (Opcional. Se não fornecido, exibe no console)
+    *   `--output-format "txt"` (Opcional, default: txt. Futuramente: md, pdf)
+    *   `--instructions "Leia atentamente cada questão."` (Opcional)
+*   **Comportamento:**
+    1.  Filtra questões do `bancoq` com base nos critérios fornecidos (subject, topic, difficulty, type, tags).
+    2.  Seleciona o número de questões especificado. Se `num-questions` for usado junto com `num-easy/medium/hard`, o sistema tenta atender às especificações de dificuldade dentro do total. Se houver conflito, prioriza `num-questions`.
+    3.  Se não houver questões suficientes no banco para atender à solicitação, informa o usuário.
+    4.  Permite ao usuário revisar as questões selecionadas e, opcionalmente, substituí-las ou adicioná-las manualmente (modo interativo avançado).
+    5.  Gera a prova no formato especificado.
+    6.  Salva os metadados da prova (struct `models.Test`) na base de dados.
+*   **Saída:**
+    *   Sucesso: "Prova '[ID_DA_PROVA] - Título da Prova' gerada com sucesso."
+    *   Se `--output-file` especificado: "Prova salva em [CAMINHO_DO_ARQUIVO]."
+    *   Se não: Exibe a prova formatada no console.
+    *   Erro: Mensagens claras (em pt-BR) se não for possível gerar a prova (e.g., "Não há questões suficientes no banco para os critérios especificados.").
+*   **Interação com BD:** Lê registros `Question`, cria um novo registro `Test`.
+
+### 3.2. `prova list`
+
+*   **Propósito:** Listar as provas já geradas.
+*   **Uso:**
+    *   `vickgenda prova list [flags]`
+*   **Flags:**
+    *   `--subject "História"` (Opcional)
+    *   `--limit 10` (Opcional, default 10)
+    *   `--page 1` (Opcional, default 1)
+    *   `--sort-by "created_at"` (Opcional, default: created_at. Outras opções: title, subject)
+    *   `--order "desc"` (Opcional, default: desc. Opções: asc, desc)
+*   **Saída:**
+    *   Tabela formatada com colunas: ID da Prova, Título, Assunto, Data de Criação, Nº de Questões.
+    *   Se nenhuma prova encontrada: "Nenhuma prova encontrada."
+*   **Interação com BD:** Lê registros `Test`.
+
+### 3.3. `prova view <id_prova>`
+
+*   **Propósito:** Visualizar uma prova específica, incluindo todas as suas questões.
+*   **Uso:**
+    *   `vickgenda prova view <ID_DA_PROVA> [--show-answers]`
+*   **Argumentos:**
+    *   `<ID_DA_PROVA>` (Obrigatório): O ID da prova.
+*   **Flags:**
+    *   `--show-answers` ou `-a`: Exibe as respostas corretas junto com as questões.
+    *   `--output-format "txt"` (Opcional, default: txt. Futuramente: md, pdf)
+*   **Saída:**
+    *   Exibição formatada da prova, incluindo cabeçalho, instruções e todas as questões.
+    *   Se `--show-answers` for usado, as respostas são mostradas.
+    *   Se não encontrada: "Prova com ID [ID_DA_PROVA] não encontrada."
+*   **Interação com BD:** Lê um registro `Test` e os registros `Question` associados.
+
+### 3.4. `prova delete <id_prova>`
+
+*   **Propósito:** Remover o registro de uma prova gerada (não remove as questões do banco).
+*   **Uso:**
+    *   `vickgenda prova delete <ID_DA_PROVA> [--force]`
+*   **Argumentos:**
+    *   `<ID_DA_PROVA>` (Obrigatório).
+*   **Flags:**
+    *   `--force` ou `-f`: Pula a confirmação.
+*   **Comportamento:**
+    *   Solicita confirmação antes de deletar, a menos que `--force` seja usado.
+*   **Saída:**
+    *   Sucesso: "Prova [ID_DA_PROVA] removida com sucesso."
+    *   Cancelado: "Remoção cancelada pelo usuário."
+    *   Erro: "Prova com ID [ID_DA_PROVA] não encontrada."
+*   **Interação com BD:** Remove um registro `Test`.
+
+### 3.5. `prova export <id_prova> <filepath>`
+
+*   **Propósito:** Exportar uma prova gerada para um arquivo em um formato específico. (Similar a `prova generate --output-file` mas para provas já existentes).
+*   **Uso:**
+    *   `vickgenda prova export <ID_DA_PROVA> <CAMINHO_DO_ARQUIVO> [flags]`
+*   **Argumentos:**
+    *   `<ID_DA_PROVA>` (Obrigatório).
+    *   `<CAMINHO_DO_ARQUIVO>` (Obrigatório).
+*   **Flags:**
+    *   `--format "txt"` (Opcional, default: txt. Futuramente: md, pdf).
+    *   `--show-answers` (Opcional, default: false).
+*   **Saída:**
+    *   Sucesso: "Prova [ID_DA_PROVA] exportada para [CAMINHO_DO_ARQUIVO]."
+    *   Erro: "Não foi possível exportar a prova. Verifique o ID e o caminho do arquivo."
+*   **Interação com BD:** Lê um registro `Test` e os `Question` associados.
+
+## 4. Considerações de Implementação
+
+*   **Seleção de Questões:** A lógica para selecionar questões deve ser robusta, lidando com casos onde não há questões suficientes que atendam aos critérios.
+*   **Randomização:** Se a randomização for implementada (ordem das questões ou alternativas), garantir que seja possível reproduzir uma prova gerada (armazenando a semente de randomização).
+*   **Formatos de Saída:** Começar com texto simples (`.txt`). Markdown (`.md`) seria um bom próximo passo. PDF é mais complexo e pode ser um objetivo futuro.
+*   **Definição da Struct `Test`:** A struct `models.Test` precisa ser definida no pacote `internal/models` antes da implementação deste comando.

--- a/internal/models/question.go
+++ b/internal/models/question.go
@@ -1,0 +1,41 @@
+package models
+
+import "time"
+
+// Question representa uma única questão no banco de questões.
+// Todo o conteúdo de texto para fins de UI deve ser tratado pela camada de apresentação,
+// esta struct foca no modelo de dados.
+type Question struct {
+	ID          string    `json:"id"`           // Identificador único (ex: UUID)
+	Subject     string    `json:"subject"`      // Matéria (ex: "Matemática", "História")
+	Topic       string    `json:"topic"`        // Tópico específico dentro da matéria (ex: "Álgebra", "Segunda Guerra Mundial")
+	Difficulty  string    `json:"difficulty"`   // Nível de dificuldade (ex: "easy", "medium", "hard" - manter em inglês para consistência de código, UI tratará a tradução)
+	QuestionText string   `json:"question_text"` // O texto real da questão
+	AnswerOptions []string `json:"answer_options,omitempty"` // Respostas possíveis para múltipla escolha, vazio para outros tipos
+	CorrectAnswers []string `json:"correct_answers"` // Resposta(s) correta(s)
+	QuestionType string   `json:"question_type"`  // Tipo de questão (ex: "multiple_choice", "true_false", "essay" - manter em inglês, UI tratará a tradução)
+	Source      string    `json:"source,omitempty"` // Opcional: Fonte da questão (ex: "Livro Didático A, Capítulo 5")
+	Tags        []string  `json:"tags,omitempty"` // Opcional: Tags para busca mais refinada
+	CreatedAt   time.Time `json:"created_at"`   // Timestamp de quando a questão foi criada
+	LastUsedAt  time.Time `json:"last_used_at,omitempty"` // Timestamp de quando a questão foi usada pela última vez em uma prova
+	Author      string    `json:"author,omitempty"`   // Opcional: Quem criou/adicionou esta questão
+}
+
+// Níveis de dificuldade (constantes de exemplo, poderia ser um enum ou definido em outro lugar)
+// Os valores das constantes (e.g., "easy") permanecem em inglês para consistência no código.
+// A interface do usuário (UI) será responsável por apresentar esses valores em pt-BR.
+const (
+	DifficultyEasy   = "easy"
+	DifficultyMedium = "medium"
+	DifficultyHard   = "hard"
+)
+
+// Tipos de questão (constantes de exemplo)
+// Os valores das constantes (e.g., "multiple_choice") permanecem em inglês para consistência no código.
+// A interface do usuário (UI) será responsável por apresentar esses valores em pt-BR.
+const (
+	QuestionTypeMultipleChoice = "multiple_choice"
+	QuestionTypeTrueFalse      = "true_false"
+	QuestionTypeEssay          = "essay"
+	QuestionTypeShortAnswer    = "short_answer"
+)


### PR DESCRIPTION
This commit corrects the language used in comments and documentation files for Squad 5 deliverables to ensure compliance with the project's language guidelines (README.md).

Corrections Made:

1.  **`internal/models/question.go`**:
    *   All Go comments have been translated to Portuguese (pt-BR).
    *   Struct names, field names, and constant values (e.g., for difficulty, question type) remain in English for internal code consistency, as specified.

2.  **`docs/schemas/question_import_schema.md`**:
    *   All descriptive text and comments within the Markdown schema definition have been translated to Portuguese (pt-BR).
    *   Example JSON values that represent UI-facing text (e.g., subject, topic, question text, answer options) are now in Portuguese (pt-BR).
    *   JSON field keys remain in English.
    *   Clarifications were added that internal enum-like values (difficulty, question_type) in the JSON should remain in English, with the UI/presentation layer responsible for localization.

These changes ensure that the codebase and documentation adhere to the specified language requirements, with user-facing text and comments in pt-BR and code identifiers in English.