### PR TITLE
feat(squad4): Implement Phase 2 UI with mock data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module professor-cli
+
+go 1.24.3
+
+require github.com/spf13/cobra v1.8.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/squad4/dashboard.go
+++ b/internal/squad4/dashboard.go
@@ -1,0 +1,72 @@
+package squad4
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var DashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Exibe o painel principal com informações resumidas.",
+	Long:  `Exibe o painel principal contendo um resumo de eventos do dia, tarefas pendentes e outras informações úteis para o professor.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		displayDashboard()
+	},
+}
+
+func displayDashboard() {
+	// Mocked data
+	userName := "Prof. Exemplo"
+	today := time.Now().Format("02/01/2006") // DD/MM/YYYY format
+
+	// Mocked events
+	events := []string{
+		"[08:00] Aula: Matemática - Turma 7B - Frações",
+		"[10:00] Reunião: Coordenação Pedagógica",
+		"[14:00] Corrigir: Provas - História - Turma 8A",
+	}
+
+	// Mocked pending tasks
+	pendingTasks := []string{
+		"[ ] Preparar aula de Ciências (Amanhã)",
+		"[ ] Lançar notas Bimestre 1 - Turma 7B (Até 25/06)",
+		"[ ] Organizar material para feira de ciências",
+	}
+
+	// Mocked focus quote
+	focusQuote := "\"Concentre-se em uma tarefa de cada vez.\""
+
+	fmt.Println("==================================================")
+	fmt.Println("                PAINEL PRINCIPAL")
+	fmt.Println("==================================================")
+	fmt.Printf("Bom dia, Professor(a) %s!\n\n", userName)
+
+	fmt.Printf("HOJE (%s):\n", today)
+	fmt.Println("--------------------------------------------------")
+	for _, event := range events {
+		fmt.Println(event)
+	}
+	fmt.Println()
+
+	fmt.Println("TAREFAS PENDENTES:")
+	fmt.Println("--------------------------------------------------")
+	for _, task := range pendingTasks {
+		fmt.Println(task)
+	}
+	fmt.Println()
+
+	fmt.Println("FOCO DO DIA:")
+	fmt.Println("--------------------------------------------------")
+	fmt.Println(focusQuote)
+	fmt.Println()
+
+	fmt.Println("--------------------------------------------------")
+	fmt.Println("Use 'ajuda' para ver todos os comandos.")
+}
+
+func init() {
+	// This function is run when the package is initialized.
+	// It's a good place to add subcommands or flags if needed in the future.
+}

--- a/internal/squad4/foco.go
+++ b/internal/squad4/foco.go
@@ -1,0 +1,108 @@
+package squad4
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings" // Added import for strings package
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var FocoCmd = &cobra.Command{
+	Use:   "foco",
+	Short: "Gerencia o modo de foco para trabalho concentrado.",
+	Long:  `Ajuda o professor a manter o foco em uma tarefa específica por um período determinado.`,
+}
+
+var focoIniciarCmd = &cobra.Command{
+	Use:   "iniciar <duração_minutos> \"<tarefa>\"",
+	Short: "Inicia uma nova sessão de foco.",
+	Long: `Inicia um temporizador para uma sessão de foco com uma duração especificada em minutos e uma descrição da tarefa.
+A descrição da tarefa deve estar entre aspas.`,
+	Example: `foco iniciar 25 "Corrigir provas Turma A"
+foco iniciar 45 "Planejar aula de História Moderna"`,
+	Args: cobra.ExactArgs(2), // duração e tarefa
+	Run: func(cmd *cobra.Command, args []string) {
+		duracaoMinutosStr := args[0]
+		tarefa := args[1]
+
+		duracaoMinutos, err := strconv.Atoi(duracaoMinutosStr)
+		if err != nil {
+			fmt.Println("Erro: A duração deve ser um número inteiro de minutos.")
+			return
+		}
+
+		if duracaoMinutos <= 0 {
+			fmt.Println("Erro: A duração deve ser maior que zero minutos.")
+			return
+		}
+
+		iniciarSessaoFoco(duracaoMinutos, tarefa)
+	},
+}
+
+func iniciarSessaoFoco(duracaoMinutos int, tarefa string) {
+	fmt.Println("==================================================")
+	fmt.Println("                            MODO FOCO")
+	fmt.Println("==================================================")
+	// This initial display matches the mockup for "Screen during focus mode"
+	// The timer will then update the "TEMPO RESTANTE" line.
+
+	duracaoTotal := time.Duration(duracaoMinutos) * time.Minute
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	startTime := time.Now()
+	endTime := startTime.Add(duracaoTotal)
+
+	// Setup signal handling for CTRL+C
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Initial display before ticker starts updating
+	fmt.Printf("\n                TEMPO RESTANTE: %02d:00\n", duracaoMinutos) // Show full minutes initially
+	fmt.Printf("\n                TAREFA: %s\n", tarefa)
+	fmt.Println("\n--------------------------------------------------")
+	fmt.Println("Mantenha o foco! Pressione CTRL+C para sair.")
+
+
+	for {
+		select {
+		case <-ticker.C:
+			tempoRestante := time.Until(endTime)
+			if tempoRestante <= 0 {
+				// Clear the "TEMPO RESTANTE" line before printing completion message
+				fmt.Printf("\r%s\r", strings.Repeat(" ", 60)) // Clear line with spaces
+				fmt.Println("==================================================")
+				fmt.Println("                            MODO FOCO") // Repeated from mockup for consistency
+				fmt.Println("==================================================")
+				fmt.Println("\n                SESSÃO CONCLUÍDA!")
+				fmt.Printf("\n                TAREFA: %s", tarefa)
+				fmt.Printf("\n                DURAÇÃO: %d minutos\n", duracaoMinutos)
+				fmt.Println("\n--------------------------------------------------")
+				fmt.Print("Bom trabalho! Deseja iniciar outra sessão? (s/N) ")
+				// For now, we just print and exit. A real app might handle input.
+				fmt.Println()
+				return
+			}
+			minutos := int(tempoRestante.Minutes())
+			segundos := int(tempoRestante.Seconds()) % 60
+			// Use carriage return to overwrite the "TEMPO RESTANTE" line
+			fmt.Printf("\r                TEMPO RESTANTE: %02d:%02d", minutos, segundos)
+		case <-sigChan:
+			// Clear the "TEMPO RESTANTE" line before printing interruption message
+			fmt.Printf("\r%s\r", strings.Repeat(" ", 60))
+			fmt.Println("\n\nSessão de foco interrompida pelo usuário.")
+			fmt.Println("--------------------------------------------------")
+			return
+		}
+	}
+}
+
+func init() {
+	FocoCmd.AddCommand(focoIniciarCmd)
+}

--- a/internal/squad4/relatorio.go
+++ b/internal/squad4/relatorio.go
@@ -1,0 +1,65 @@
+package squad4
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var RelatorioCmd = &cobra.Command{
+	Use:   "relatorio",
+	Short: "Gera relatórios sobre atividades, produtividade e desempenho.",
+	Long:  `Permite gerar diferentes tipos de relatórios para fornecer insights ao professor.`,
+}
+
+var relatorioProdutividadeCmd = &cobra.Command{
+	Use:   "produtividade [semanal|mensal|bimestral]",
+	Short: "Gera um relatório de produtividade.",
+	Long:  `Mostra um relatório sobre tarefas concluídas, tempo gasto em eventos, etc.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		periodo := "geral"
+		if len(args) > 0 {
+			periodo = args[0]
+		}
+		fmt.Printf("O relatório de produtividade (%s) ainda não foi implementado.\n", periodo)
+		fmt.Println("Este relatório mostrará dados como:")
+		fmt.Println("- Número de tarefas criadas, concluídas, pendentes.")
+		fmt.Println("- Tempo médio para completar tarefas.")
+		fmt.Println("- Tempo gasto em reuniões/eventos.")
+		fmt.Println("Consulte 'data_requirements_relatorio.md' para mais detalhes sobre os dados necessários.")
+	},
+}
+
+var relatorioAcademicoCmd = &cobra.Command{
+	Use:   "academico [turma <nome_turma>|disciplina <nome_disciplina>] [bimestre <num>]",
+	Short: "Gera um relatório de desempenho acadêmico.",
+	Long:  `Mostra um relatório sobre notas, progresso de alunos, etc.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("O relatório acadêmico ainda não foi implementado.")
+		fmt.Println("Este relatório mostrará dados como:")
+		fmt.Println("- Médias de notas por turma/disciplina.")
+		fmt.Println("- Distribuição de notas.")
+		fmt.Println("- Alunos precisando de atenção.")
+		fmt.Println("Consulte 'data_requirements_relatorio.md' para mais detalhes sobre os dados necessários.")
+	},
+}
+
+var relatorioUsoConteudoCmd = &cobra.Command{
+	Use:   "uso-conteudo [disciplina <nome_disciplina>]",
+	Short: "Gera um relatório sobre o uso de conteúdo pedagógico.",
+	Long:  `Mostra estatísticas sobre o banco de questões, criação de provas, etc.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("O relatório de uso de conteúdo ainda não foi implementado.")
+		fmt.Println("Este relatório mostrará dados como:")
+		fmt.Println("- Número de questões por disciplina/tópico/dificuldade.")
+		fmt.Println("- Frequência de uso de questões em provas.")
+		fmt.Println("- Tempo médio para criar testes.")
+		fmt.Println("Consulte 'data_requirements_relatorio.md' para mais detalhes sobre os dados necessários.")
+	},
+}
+
+func init() {
+	RelatorioCmd.AddCommand(relatorioProdutividadeCmd)
+	RelatorioCmd.AddCommand(relatorioAcademicoCmd)
+	RelatorioCmd.AddCommand(relatorioUsoConteudoCmd)
+}

--- a/internal/squad4/relembrar.go
+++ b/internal/squad4/relembrar.go
@@ -1,0 +1,80 @@
+package squad4
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var RelembrarCmd = &cobra.Command{
+	Use:   "relembrar",
+	Short: "Gerencia lembretes.",
+	Long:  `Permite adicionar e listar lembretes para ajudar o professor a se organizar.`,
+}
+
+var relembrarAdicionarCmd = &cobra.Command{
+	Use:   "adicionar \"<lembrete>\" <data> [hora]",
+	Short: "Adiciona um novo lembrete.",
+	Long: `Adiciona um novo lembrete com uma descrição, data e, opcionalmente, uma hora.
+A descrição do lembrete deve estar entre aspas.
+Formato da data: DD/MM/YYYY ou palavras-chave como "hoje", "amanha".
+Formato da hora (opcional): HH:MM.`,
+	Example: `relembrar adicionar "Comprar canetas vermelhas" amanha 10:00
+relembrar adicionar "Buscar provas na gráfica" 23/07/2025`,
+	Args: cobra.MinimumNArgs(2), // lembrete e data são obrigatórios
+	Run: func(cmd *cobra.Command, args []string) {
+		lembrete := args[0]
+		data := args[1]
+		hora := ""
+		if len(args) > 2 {
+			hora = args[2]
+		}
+
+		// Mocked interaction: Just print a confirmation
+		if hora != "" {
+			fmt.Printf("Lembrete '%s' adicionado para %s %s.\n", lembrete, data, hora)
+		} else {
+			fmt.Printf("Lembrete '%s' adicionado para %s.\n", lembrete, data)
+		}
+		// In a real application, this would be saved to a database or other storage.
+	},
+}
+
+var relembrarListarCmd = &cobra.Command{
+	Use:   "listar",
+	Short: "Lista todos os lembretes.",
+	Long:  `Exibe uma lista de todos os lembretes pendentes.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Mocked data based on mockups.txt
+		type LembreteMock struct {
+			ID        int
+			Descricao string
+			Data      string
+			Hora      string
+		}
+		lembretes := []LembreteMock{
+			{ID: 1, Descricao: "Comprar canetas", Data: "21/06/2025", Hora: "10:00"},
+			{ID: 2, Descricao: "Ligar para gráfica", Data: "24/06/2025", Hora: "15:30"},
+			{ID: 3, Descricao: "Confirmar reunião", Data: "HOJE", Hora: "17:00"},
+			// Adding one more from Phase 2 requirements example
+			{ID: 4, Descricao: "Preparar aula de Biologia", Data: "Amanhã", Hora: "09:00"},
+		}
+
+		fmt.Println("==================================================")
+		fmt.Println("                            LEMBRETES")
+		fmt.Println("==================================================")
+		fmt.Printf("%-3s %-30s %-12s %-8s\n", "ID", "LEMBRETE", "DATA", "HORA")
+		fmt.Printf("--- %-30s %-12s %-8s\n", strings.Repeat("-", 30), strings.Repeat("-", 12), strings.Repeat("-", 8))
+
+		for _, l := range lembretes {
+			fmt.Printf("%-3d %-30s %-12s %-8s\n", l.ID, l.Descricao, l.Data, l.Hora)
+		}
+		// In a real application, this data would be fetched from storage.
+	},
+}
+
+func init() {
+	RelembrarCmd.AddCommand(relembrarAdicionarCmd)
+	RelembrarCmd.AddCommand(relembrarListarCmd)
+}

--- a/internal/squad4/squad4.go
+++ b/internal/squad4/squad4.go
@@ -1,0 +1,14 @@
+package squad4
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// InitSquad4Commands initializes and adds all Squad 4 commands to the provided root command.
+func InitSquad4Commands(rootCmd *cobra.Command) {
+	// Add top-level commands from Squad 4
+	rootCmd.AddCommand(DashboardCmd)
+	rootCmd.AddCommand(RelembrarCmd) // RelembrarCmd itself has subcommands (adicionar, listar)
+	rootCmd.AddCommand(FocoCmd)       // FocoCmd itself has subcommands (iniciar)
+	rootCmd.AddCommand(RelatorioCmd)  // RelatorioCmd itself has subcommands (produtividade, etc.)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	// Ensure this import path matches your module name in go.mod + path to package
+	"professor-cli/internal/squad4"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "professor-cli",
+	Short: "Professor CLI é uma ferramenta para auxiliar professores em suas tarefas diárias.",
+	Long: `Uma interface de linha de comando para ajudar professores com gerenciamento de tarefas,
+agenda, notas, foco, e mais.`,
+	// Uncomment the following line if you want to print help when no subcommand is provided
+	// Run: func(cmd *cobra.Command, args []string) { cmd.Help() },
+}
+
+func main() {
+	// Initialize Squad 4 commands and add them to the root command
+	squad4.InitSquad4Commands(rootCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Erro ao executar o comando: '%s'\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This commit introduces the initial CLI command structure and UI for Squad 4 (Experiência Principal, Foco e Insights) modules, as per Phase 2 requirements.

Modules Implemented:
- dashboard: Displays a mock dashboard with daily overview.
- relembrar: Allows adding (mocked) and listing (mocked) reminders.
- foco: Implements a focus timer with task display.
- relatorio: Sets up placeholder command structure for future report generation.

Key Changes:
- Added Go files for each command in `internal/squad4/`.
- Created `main.go` as the application entry point.
- Integrated `github.com/spf13/cobra` for CLI command handling.
- Initialized Go modules (`go.mod`, `go.sum`).
- All data is currently mocked, pending integration in Phase 3.

This fulfills the Phase 2 objectives for Squad 4, providing a runnable application skeleton with the core UI elements in place.