### PR TITLE
Here's the commit message with the updates:

### DIFF
--- a/cmd/prova/delete.go
+++ b/cmd/prova/delete.go
@@ -1,0 +1,96 @@
+package prova
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"vickgenda-cli/internal/models"
+)
+
+// Sample tests for simulation - this list will be modified by the delete operation.
+// It needs to be a package-level variable to persist changes across calls in a real scenario,
+// but for a single command execution simulation, it's fine.
+// For more robust state between CLI calls, an actual DB or file store would be needed.
+var sampleGeneratedProvasForDelete = []models.Test{
+	{ID: "del123", Title: "Prova de Exatas Antiga", Subject: "Matemática", CreatedAt: time.Now().Add(-72 * time.Hour), QuestionIDs: []string{"q1", "q4"}},
+	{ID: "del456", Title: "Teste de Humanas Passado", Subject: "História", CreatedAt: time.Now().Add(-96 * time.Hour), QuestionIDs: []string{"q3"}},
+	{ID: "del789", Title: "Avaliação Rápida de Geografia", Subject: "Geografia", CreatedAt: time.Now().Add(-120 * time.Hour), QuestionIDs: []string{"q5"}},
+}
+
+// deleteCmd representa o comando para remover uma prova.
+var deleteCmd = &cobra.Command{
+	Use:   "delete <id_prova>",
+	Short: "Remove uma prova",
+	Long:  `Remove uma prova do sistema com base no seu ID.`,
+	Args:  cobra.ExactArgs(1), // Espera exatamente um argumento: o ID da prova.
+	Run: func(cmd *cobra.Command, args []string) {
+		provaID := args[0] // Already validated by cobra.ExactArgs(1)
+		force, _ := cmd.Flags().GetBool("force")
+
+		fmt.Printf("Executando o comando 'prova delete' para a Prova ID: %s\n", provaID)
+
+		// 1. Encontrar a prova
+		foundIndex := -1
+		var provaTitle string
+		for i, p := range sampleGeneratedProvasForDelete {
+			if p.ID == provaID {
+				foundIndex = i
+				provaTitle = p.Title // Guardar o título para a mensagem de confirmação/sucesso
+				break
+			}
+		}
+
+		if foundIndex == -1 {
+			fmt.Printf("Erro: Prova com ID '%s' não encontrada na lista de simulação.\n", provaID)
+			return
+		}
+
+		// 2. Confirmação (se --force não for usado)
+		proceedToDelete := false
+		if force {
+			fmt.Println("Opção --force utilizada. Removendo a prova diretamente.")
+			proceedToDelete = true
+		} else {
+			fmt.Printf("\nTem certeza que deseja remover a prova '%s' (ID: %s)?\n", provaTitle, provaID)
+			fmt.Print("Esta ação não pode ser desfeita. Digite 'sim' para confirmar: ")
+
+			reader := bufio.NewReader(os.Stdin)
+			input, _ := reader.ReadString('\n')
+			input = strings.TrimSpace(strings.ToLower(input))
+
+			if input == "sim" {
+				proceedToDelete = true
+			} else {
+				fmt.Println("Remoção cancelada pelo usuário.")
+			}
+		}
+
+		// 3. Remover a prova (se confirmado ou forçado)
+		if proceedToDelete {
+			// Remover o elemento da slice
+			sampleGeneratedProvasForDelete = append(sampleGeneratedProvasForDelete[:foundIndex], sampleGeneratedProvasForDelete[foundIndex+1:]...)
+			fmt.Printf("\nProva '%s' (ID: %s) removida com sucesso.\n", provaTitle, provaID)
+
+			// Opcional: Mostrar a lista restante para verificar (para fins de depuração/simulação)
+			fmt.Println("\nLista de provas restantes (simulação):")
+			if len(sampleGeneratedProvasForDelete) == 0 {
+				fmt.Println("Nenhuma prova restante.")
+			} else {
+				for _, p := range sampleGeneratedProvasForDelete {
+					fmt.Printf("- ID: %s, Título: %s\n", p.ID, p.Title)
+				}
+			}
+		}
+		fmt.Println("\nComando 'prova delete' concluído.")
+	},
+}
+
+func init() {
+	ProvaCmd.AddCommand(deleteCmd)
+	// Flags para o comando delete (baseado em docs/specifications/prova_command_spec.md):
+	deleteCmd.Flags().BoolP("force", "f", false, "Forçar a remoção da prova sem confirmação (opcional, padrão: false)")
+}

--- a/cmd/prova/export.go
+++ b/cmd/prova/export.go
@@ -1,0 +1,246 @@
+package prova
+
+import (
+	"fmt"
+	"os" // Required for os.WriteFile in actual implementation, used for placeholder message here
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"vickgenda-cli/internal/models"
+)
+
+// --- Reusing sample data structures (similar to view.go) ---
+
+var sampleGeneratedProvasForExport = []models.Test{
+	{ID: "exp123", Title: "Prova de Matemática para Exportar", Subject: "Matemática", CreatedAt: time.Now().Add(-24 * time.Hour), QuestionIDs: []string{"qExp1", "qExp2", "qMissingExp"}, Instructions: "Exportar esta prova."},
+	{ID: "exp456", Title: "Avaliação de História para Exportar", Subject: "História", CreatedAt: time.Now().Add(-48 * time.Hour), QuestionIDs: []string{"qExp3"}, Instructions: "Verificar formato de exportação."},
+}
+
+var sampleQuestionsForExport = []models.Question{
+	{ID: "qExp1", Subject: "Matemática", Text: "Qual o resultado de 10+10?", Type: "multipla_escolha", Difficulty: "fácil", Options: []models.QuestionOption{{Text: "15"}, {Text: "20", IsCorrect: true}, {Text: "25"}}, CorrectAnswers: []string{"20"}},
+	{ID: "qExp2", Subject: "Matemática", Text: "O que é uma equação?", Type: "dissertativa", Difficulty: "médio", CorrectAnswers: []string{"Uma igualdade envolvendo uma ou mais incógnitas."}},
+	{ID: "qExp3", Subject: "História", Text: "Quem foi o primeiro presidente do Brasil?", Type: "multipla_escolha", Difficulty: "difícil", Options: []models.QuestionOption{{Text: "Deodoro da Fonseca", IsCorrect: true}, {Text: "Prudente de Morais"}}, CorrectAnswers: []string{"Deodoro da Fonseca"}},
+}
+
+// Helper to find a Test by ID
+func findTestByIDForExport(id string, tests []models.Test) *models.Test {
+	for i := range tests {
+		if tests[i].ID == id {
+			return &tests[i]
+		}
+	}
+	return nil
+}
+
+// Helper to find a Question by ID
+func findQuestionByIDForExport(id string, questions []models.Question) *models.Question {
+	for i := range questions {
+		if questions[i].ID == id {
+			return &questions[i]
+		}
+	}
+	return nil
+}
+// --- End of sample data ---
+
+// exportCmd representa o comando para exportar uma prova.
+var exportCmd = &cobra.Command{
+	Use:   "export <id_prova> <filepath>",
+	Short: "Exporta uma prova para um arquivo",
+	Long:  `Exporta os dados de uma prova específica para um arquivo em um formato especificado (ex: JSON, PDF).`,
+	Args:  cobra.ExactArgs(2), // Espera dois argumentos: ID da prova e caminho do arquivo.
+	Run: func(cmd *cobra.Command, args []string) {
+		provaID := args[0]   // Validated by cobra.ExactArgs(2)
+		filepath := args[1] // Validated by cobra.ExactArgs(2)
+
+		exportFormat, _ := cmd.Flags().GetString("format") // Renamed to avoid conflict
+		showAnswers, _ := cmd.Flags().GetBool("show-answers")
+
+		fmt.Printf("Executando o comando 'prova export' para a Prova ID: %s\n", provaID)
+		fmt.Printf("Caminho do arquivo de saída: %s, Formato: %s, Incluir Respostas: %t\n", filepath, exportFormat, showAnswers)
+
+		// 1. Validar formato de exportação (focando em 'txt')
+		if exportFormat != "txt" {
+			// For other formats like json, pdf, html, specific libraries or logic would be needed.
+			// For now, we'll warn and default to a text-like representation if attempting others.
+			fmt.Printf("AVISO: Formato de exportação '%s' não é totalmente suportado para escrita em arquivo nesta simulação. O conteúdo gerado será textual.\n", exportFormat)
+			// Potentially default to .txt extension for filepath if format is not txt.
+		}
+
+		// 2. Encontrar a prova
+		prova := findTestByIDForExport(provaID, sampleGeneratedProvasForExport)
+		if prova == nil {
+			fmt.Printf("Erro: Prova com ID '%s' não encontrada.\n", provaID)
+			return
+		}
+
+		// 3. Buscar detalhes das questões
+		var fetchedQuestions []*models.Question
+		questionsMap := make(map[string]*models.Question)
+
+		// fmt.Println("\n[Simulação] Buscando detalhes das questões da prova para exportação...")
+		for _, qID := range prova.QuestionIDs {
+			if _, exists := questionsMap[qID]; exists {
+				continue
+			}
+			question := findQuestionByIDForExport(qID, sampleQuestionsForExport)
+			if question != nil {
+				fetchedQuestions = append(fetchedQuestions, question)
+				questionsMap[qID] = question // Store in map for ordered access later
+			} else {
+				fmt.Printf("AVISO: Questão com ID '%s' (listada na prova) não foi encontrada no banco de questões de simulação.\n", qID)
+				// Create a placeholder to maintain order and indicate missing data
+				placeholderQuestion := &models.Question{ID: qID, Text: fmt.Sprintf("[Questão com ID '%s' não encontrada]", qID), Type: "desconhecido"}
+				fetchedQuestions = append(fetchedQuestions, placeholderQuestion)
+				questionsMap[qID] = placeholderQuestion
+			}
+		}
+
+		// Reorder fetchedQuestions according to prova.QuestionIDs
+		orderedFetchedQuestions := make([]*models.Question, len(prova.QuestionIDs))
+		for i, qID := range prova.QuestionIDs {
+			orderedFetchedQuestions[i] = questionsMap[qID]
+		}
+
+
+		// 4. Formatar conteúdo para exportação (usando a nova função)
+		// Passando `orderedFetchedQuestions` para manter a ordem da prova.
+		formattedContent, err := formatTestContentForExport(prova, orderedFetchedQuestions, exportFormat, showAnswers)
+		if err != nil {
+			fmt.Printf("Erro ao formatar conteúdo da prova: %v\n", err)
+			return
+		}
+
+		// 5. Simular Escrita em Arquivo
+		fmt.Printf("\n--- Simulação de Exportação para Arquivo ---\n")
+		fmt.Printf("Arquivo: %s\n", filepath)
+		fmt.Printf("Formato: %s\n", exportFormat)
+		fmt.Println("Conteúdo (primeiras ~250 chars):")
+
+		contentPreview := formattedContent
+		if len(contentPreview) > 250 {
+			contentPreview = contentPreview[:250] + "..."
+		}
+		fmt.Println(contentPreview)
+		fmt.Println("-----------------------------------------")
+
+		// Placeholder para a escrita real do arquivo:
+		// if exportFormat == "txt" { // Ou outros formatos baseados em texto
+		// 	err := os.WriteFile(filepath, []byte(formattedContent), 0644)
+		// 	if err != nil {
+		// 		fmt.Fprintf(os.Stderr, "Erro (simulado) ao escrever prova no arquivo '%s': %v\n", filepath, err)
+		// 		return // ou cmd.SilenceUsage = true; return err
+		// 	}
+		// 	fmt.Printf("\nProva exportada com sucesso para: %s\n", filepath)
+		// } else if exportFormat == "json" {
+		//    // jsonBytes, _ := json.MarshalIndent(provaComQuestoes, "", "  ")
+		//    // os.WriteFile(filepath, jsonBytes, 0644) ...
+		// } // etc. for pdf, html
+
+		fmt.Println("\nComando 'prova export' concluído com lógica de simulação.")
+	},
+}
+
+// Helper function to format test content (similar to view.go logic)
+// This could be moved to a shared formatter package later.
+func formatTestContentForExport(test *models.Test, questions []*models.Question, formatType string, showAnswers bool) (string, error) {
+	if test == nil {
+		return "", fmt.Errorf("prova (test) não pode ser nula")
+	}
+
+	// For now, only "txt" is implemented for direct string generation
+	if formatType != "txt" {
+		// In a real scenario, you might return an error or handle other formats.
+		// For this simulation, we'll just note it and proceed with txt-like formatting.
+		// No need to print here, calling function can decide.
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("Título: %s\n", test.Title))
+	sb.WriteString(fmt.Sprintf("Disciplina: %s\n", test.Subject))
+	if test.Instructions != "" {
+		sb.WriteString(fmt.Sprintf("Instruções: %s\n", test.Instructions))
+	}
+	if test.RandomizationSeed > 0 {
+		sb.WriteString(fmt.Sprintf("(Randomizado com semente: %d)\n", test.RandomizationSeed))
+	}
+	sb.WriteString("------------------------------------\n\n")
+
+	if len(questions) == 0 { // Based on the actual questions passed
+		sb.WriteString("Esta prova não contém questões ou as questões não puderam ser carregadas.\n")
+	} else {
+		for i, question := range questions {
+			if question == nil { // Should not happen if list is pre-filtered or placeholders used
+				sb.WriteString(fmt.Sprintf("%d. [Erro - Questão nula na lista]\n\n", i+1))
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("%d. (ID: %s) %s\n", i+1, question.ID, question.Text))
+
+			if strings.HasPrefix(question.Text, "[Questão com ID") && strings.HasSuffix(question.Text, "não encontrada]") {
+				sb.WriteString("\n"); // Extra space for missing questions
+				continue;
+			}
+
+
+			if question.Type == "multipla_escolha" {
+				if len(question.Options) > 0 {
+					// sb.WriteString("   Opções:\n") // Removed for cleaner export
+					for j, opt := range question.Options {
+						prefix := fmt.Sprintf("  %c)", 'A'+j)
+						marker := "" // No marker for plain export unless answers are shown
+						if showAnswers {
+							marker = "[ ]" // Default for showAnswers
+							for _, correctAns := range question.CorrectAnswers {
+								if strings.EqualFold(opt.Text, correctAns) {
+									marker = "[*]"
+									break
+								}
+							}
+						}
+						sb.WriteString(fmt.Sprintf("%s %s %s\n", prefix, marker, opt.Text))
+					}
+				} else {
+					// sb.WriteString("   AVISO: Questão de múltipla escolha sem opções definidas.\n")
+				}
+			}
+
+			if showAnswers {
+				if len(question.CorrectAnswers) > 0 {
+					if question.Type == "dissertativa" || (question.Type == "multipla_escolha" && len(question.Options) == 0) {
+						sb.WriteString(fmt.Sprintf("   Resposta Correta: %s\n", strings.Join(question.CorrectAnswers, " | ")))
+					} else if question.Type == "multipla_escolha" && len(question.Options) > 0 && markerHasNotShownAllAnswers(question) {
+						// If markers didn't show all, or for a summary
+						sb.WriteString(fmt.Sprintf("   Gabarito: %s\n", strings.Join(question.CorrectAnswers, " | ")))
+					}
+				} else if question.Type != "multipla_escolha" || len(question.Options) == 0 { // Avoid for MC with options if no correct answer is set
+					// sb.WriteString("   AVISO: Resposta correta não disponível.\n")
+				}
+			}
+			sb.WriteString("\n") // Add a blank line after each question for readability
+		}
+	}
+	sb.WriteString("------------------------------------\n")
+	return sb.String(), nil
+}
+
+// Helper to check if all correct answers for MC were already marked (e.g. if CorrectAnswers contains option letters not texts)
+// This is a placeholder, actual logic might be more complex if CorrectAnswers stores A,B,C instead of full text.
+func markerHasNotShownAllAnswers(q *models.Question) bool {
+	// If CorrectAnswers stores text and we marked based on text, this might be true.
+	// If CorrectAnswers stores letters 'A', 'B', etc., then markers are the primary way.
+	// For this simulation, assume if CorrectAnswers has entries, and we are showing answers,
+	// we might want to list them explicitly if they are not just option texts.
+	return true // Simplified: always show explicit gabarito if available and showAnswers is true for MC
+}
+
+
+func init() {
+	ProvaCmd.AddCommand(exportCmd)
+	// Flags para o comando export (baseado em docs/specifications/prova_command_spec.md):
+	exportCmd.Flags().StringP("format", "f", "txt", "Formato do arquivo de exportação (ex: txt, json, pdf, html) (opcional, padrão: txt)")
+	exportCmd.Flags().Bool("show-answers", false, "Incluir respostas das questões na exportação (opcional, padrão: false)")
+	// A flag "template" foi mencionada no setup inicial mas não no doc. Mantendo as do doc.
+	// exportCmd.Flags().String("template", "", "Caminho para um template customizado de exportação (ex: para PDF ou HTML)")
+}

--- a/cmd/prova/generate.go
+++ b/cmd/prova/generate.go
@@ -1,0 +1,306 @@
+package prova
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"vickgenda-cli/internal/models" // Assuming models.Question and models.Test are defined here
+)
+
+// Sample questions for simulation
+var sampleQuestions = []models.Question{
+	{ID: "q1", Subject: "Matemática", Text: "Quanto é 2+2?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"aritmética"}, Tags: []string{"básica"}, Options: []models.QuestionOption{{Text: "3", IsCorrect: false}, {Text: "4", IsCorrect: true}, {Text: "5", IsCorrect: false}}},
+	{ID: "q2", Subject: "Matemática", Text: "Quanto é 5*8?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"aritmética"}, Tags: []string{"básica"}, Options: []models.QuestionOption{{Text: "30", IsCorrect: false}, {Text: "40", IsCorrect: true}, {Text: "35", IsCorrect: false}}},
+	{ID: "q3", Subject: "História", Text: "Quem descobriu o Brasil?", Type: "dissertativa", Difficulty: "médio", Topics: []string{"descobrimentos"}, Tags: []string{"Brasil"}},
+	{ID: "q4", Subject: "Matemática", Text: "Qual a derivada de x^2?", Type: "dissertativa", Difficulty: "difícil", Topics: []string{"cálculo"}, Tags: []string{"avançada"}},
+	{ID: "q5", Subject: "Geografia", Text: "Qual a capital da França?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"europa"}, Tags: []string{"capitais"}, Options: []models.QuestionOption{{Text: "Londres", IsCorrect: false}, {Text: "Paris", IsCorrect: true}, {Text: "Madri", IsCorrect: false}}},
+	{ID: "q6", Subject: "Matemática", Text: "Resolva a equação: x + 5 = 10", Type: "dissertativa", Difficulty: "fácil", Topics: []string{"algebra"}, Tags: []string{"equação"}},
+	{ID: "q7", Subject: "História", Text: "Em que ano começou a Segunda Guerra Mundial?", Type: "multipla_escolha", Difficulty: "médio", Topics: []string{"guerras mundiais"}, Tags: []string{"século XX"}, Options: []models.QuestionOption{{Text: "1939", IsCorrect: true}, {Text: "1941", IsCorrect: false}, {Text: "1945", IsCorrect: false}}},
+	{ID: "q8", Subject: "Matemática", Text: "Qual o valor de Pi (aproximado)?", Type: "multipla_escolha", Difficulty: "médio", Topics: []string{"geometria"}, Tags: []string{"constantes"}, Options: []models.QuestionOption{{Text: "3.14", IsCorrect: true}, {Text: "3.12", IsCorrect: false}, {Text: "3.16", IsCorrect: false}}},
+	{ID: "q9", Subject: "Matemática", Text: "O que é um número primo?", Type: "dissertativa", Difficulty: "médio", Topics: []string{"teoria dos números"}, Tags: []string{"definição"}},
+	{ID: "q10", Subject: "Matemática", Text: "Qual a área de um círculo de raio r?", Type: "dissertativa", Difficulty: "difícil", Topics: []string{"geometria"}, Tags: []string{"fórmula"}},
+}
+
+// generateCmd representa o comando para gerar uma nova prova.
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Gera uma nova prova",
+	Long:  `Gera uma nova prova com base em questões existentes, permitindo especificar diversos parâmetros.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Executando o comando 'prova generate'...")
+
+		// Recuperar valores das flags
+		title, _ := cmd.Flags().GetString("title")
+		subjectFilter, _ := cmd.Flags().GetString("subject") // Renomeado para evitar conflito com prova.Subject
+		topicsFilter, _ := cmd.Flags().GetStringSlice("topic")
+		difficultiesFilter, _ := cmd.Flags().GetStringSlice("difficulty")
+		typesFilter, _ := cmd.Flags().GetStringSlice("type")
+		tagsFilter, _ := cmd.Flags().GetStringSlice("tag")
+		numQuestionsTotal, _ := cmd.Flags().GetInt("num-questions")
+		numEasy, _ := cmd.Flags().GetInt("num-easy")
+		numMedium, _ := cmd.Flags().GetInt("num-medium")
+		numHard, _ := cmd.Flags().GetInt("num-hard")
+		// allowDuplicates, _ := cmd.Flags().GetBool("allow-duplicates") // Implementar se necessário
+		randomizeOrder, _ := cmd.Flags().GetBool("randomize-order")
+		outputFile, _ := cmd.Flags().GetString("output-file")
+		// outputFormat, _ := cmd.Flags().GetString("output-format") // Usaremos TXT simples por enquanto
+		instructions, _ := cmd.Flags().GetString("instructions")
+
+		fmt.Println("\n--- Critérios Iniciais para Geração da Prova ---")
+		fmt.Printf("Título: %s, Disciplina: %s\n", title, subjectFilter)
+		// Adicionar mais prints dos filtros se necessário para debug
+
+		// 1. Filtrar questões (simulação)
+		var filteredQuestions []models.Question
+		for _, q := range sampleQuestions {
+			match := true
+			if subjectFilter != "" && !strings.EqualFold(q.Subject, subjectFilter) {
+				match = false
+			}
+			if len(topicsFilter) > 0 && !containsAny(q.Topics, topicsFilter) {
+				match = false
+			}
+			if len(difficultiesFilter) > 0 && !contains(difficultiesFilter, q.Difficulty) {
+				match = false
+			}
+			if len(typesFilter) > 0 && !contains(typesFilter, q.Type) {
+				match = false
+			}
+			if len(tagsFilter) > 0 && !containsAny(q.Tags, tagsFilter) {
+				match = false
+			}
+			if match {
+				filteredQuestions = append(filteredQuestions, q)
+			}
+		}
+
+		if len(filteredQuestions) == 0 {
+			fmt.Println("Nenhuma questão encontrada com os critérios especificados.")
+			return
+		}
+		fmt.Printf("Total de questões filtradas inicialmente: %d\n", len(filteredQuestions))
+
+		// 2. Selecionar questões
+		var selectedQuestions []models.Question
+		var randomizationSeed int64 // Para guardar a semente se randomização for usada
+
+		if numQuestionsTotal > 0 {
+			// Selecionar aleatoriamente do total filtrado
+			if randomizeOrder {
+				rand.Seed(time.Now().UnixNano()) // Inicializa a semente
+				randomizationSeed = rand.Int63()  // Guarda a semente
+				rand.Shuffle(len(filteredQuestions), func(i, j int) {
+					filteredQuestions[i], filteredQuestions[j] = filteredQuestions[j], filteredQuestions[i]
+				})
+			}
+			for i := 0; i < numQuestionsTotal && i < len(filteredQuestions); i++ {
+				selectedQuestions = append(selectedQuestions, filteredQuestions[i])
+			}
+		} else if numEasy > 0 || numMedium > 0 || numHard > 0 {
+			// Selecionar por dificuldade
+			questionsByDifficulty := map[string][]models.Question{
+				"fácil":   {},
+				"médio":   {},
+				"difícil": {},
+			}
+			for _, q := range filteredQuestions {
+				questionsByDifficulty[q.Difficulty] = append(questionsByDifficulty[q.Difficulty], q)
+			}
+
+			if randomizeOrder { // Randomizar dentro de cada categoria de dificuldade antes de selecionar
+				rand.Seed(time.Now().UnixNano())
+				randomizationSeed = rand.Int63()
+				for k := range questionsByDifficulty {
+					rand.Shuffle(len(questionsByDifficulty[k]), func(i, j int) {
+						questionsByDifficulty[k][i], questionsByDifficulty[k][j] = questionsByDifficulty[k][j], questionsByDifficulty[k][i]
+					})
+				}
+			}
+
+			selectFromCategory := func(category string, count int) {
+				available := questionsByDifficulty[category]
+				for i := 0; i < count && i < len(available); i++ {
+					selectedQuestions = append(selectedQuestions, available[i])
+				}
+			}
+			selectFromCategory("fácil", numEasy)
+			selectFromCategory("médio", numMedium)
+			selectFromCategory("difícil", numHard)
+			// Nota: Não estamos tratando --allow-duplicates explicitamente, a seleção acima já evita duplicatas.
+			// Se o número total de questões selecionadas por dificuldade for importante,
+			// pode ser necessário ajustar ou limitar ao numQuestionsTotal se este também for fornecido.
+		} else {
+			// Se nenhum critério numérico for dado, selecionar todas as filtradas ou um padrão (ex: 10)
+			if randomizeOrder {
+				rand.Seed(time.Now().UnixNano())
+				randomizationSeed = rand.Int63()
+				rand.Shuffle(len(filteredQuestions), func(i, j int) {
+					filteredQuestions[i], filteredQuestions[j] = filteredQuestions[j], filteredQuestions[i]
+				})
+			}
+			maxDefaultQuestions := 10
+			if len(filteredQuestions) < maxDefaultQuestions {
+				maxDefaultQuestions = len(filteredQuestions)
+			}
+			selectedQuestions = filteredQuestions[:maxDefaultQuestions]
+		}
+
+		if len(selectedQuestions) == 0 {
+			fmt.Println("Não foi possível selecionar questões com os números especificados a partir das questões filtradas.")
+			return
+		}
+
+		// Se randomizeOrder foi global e não por dificuldade, e não foi feito antes
+		if randomizeOrder && numQuestionsTotal > 0 { // Já feito acima para numQuestionsTotal
+			// Se a seleção foi por dificuldade, e queremos randomizar o conjunto final
+			// rand.Seed(time.Now().UnixNano()) // Semente já inicializada se randomizeOrder=true
+			// randomizationSeed = rand.Int63() // Semente já guardada
+			rand.Shuffle(len(selectedQuestions), func(i, j int) {
+				selectedQuestions[i], selectedQuestions[j] = selectedQuestions[j], selectedQuestions[i]
+			})
+		}
+
+
+		// 3. Criar objeto models.Test
+		questionIDs := make([]string, len(selectedQuestions))
+		for i, q := range selectedQuestions {
+			questionIDs[i] = q.ID
+		}
+
+		prova := models.Test{
+			ID:                uuid.NewString(),
+			Title:             title,
+			Subject:           subjectFilter, // Usar o subject do filtro como o principal da prova
+			CreatedAt:         time.Now(),
+			Instructions:      instructions,
+			QuestionIDs:       questionIDs,
+			LayoutOptions:     make(map[string]string), // Pode ser preenchido com defaults ou futuras flags
+			RandomizationSeed: 0,                       // Definir se a randomização ocorreu
+		}
+		if randomizeOrder && randomizationSeed != 0 {
+			prova.RandomizationSeed = randomizationSeed
+		}
+
+
+		fmt.Printf("\n--- Prova Gerada (Objeto models.Test) ---\n")
+		fmt.Printf("%+v\n", prova)
+		fmt.Println("------------------------------------")
+
+		// 4. Simular Saída
+		if outputFile != "" {
+			fmt.Printf("\nSimulando salvamento da prova em: %s\n", outputFile)
+			// Aqui ocorreria a escrita no arquivo, usando o outputFormat se necessário.
+			// Por agora, apenas a mensagem.
+		} else {
+			fmt.Printf("\n--- Visualização da Prova (Formato Texto Simples) ---\n")
+			fmt.Printf("Título: %s\n", prova.Title)
+			fmt.Printf("Disciplina: %s\n", prova.Subject)
+			if prova.Instructions != "" {
+				fmt.Printf("Instruções: %s\n", prova.Instructions)
+			}
+			if prova.RandomizationSeed != 0 {
+				fmt.Printf("(Questões/alternativas randomizadas com semente: %d)\n", prova.RandomizationSeed)
+			}
+			fmt.Println("---")
+
+			for i, qID := range prova.QuestionIDs {
+				var questionText, questionType string
+				var options []string
+				// Encontrar a questão original no sampleQuestions para obter detalhes
+				// Em um sistema real, buscaria do DB
+				originalQuestion := findQuestionByID(qID, sampleQuestions)
+				if originalQuestion != nil {
+					questionText = originalQuestion.Text
+					questionType = originalQuestion.Type
+					if originalQuestion.Type == "multipla_escolha" {
+						for _, opt := range originalQuestion.Options {
+							options = append(options, opt.Text)
+						}
+					}
+				} else {
+					questionText = "Texto da questão não encontrado (ID: " + qID + ")"
+				}
+
+				fmt.Printf("\nQuestão %d (ID: %s, Tipo: %s): %s\n", i+1, qID, questionType, questionText)
+				if len(options) > 0 {
+					fmt.Println("Opções:")
+					for j, optText := range options {
+						fmt.Printf("  %c) %s\n", 'A'+j, optText)
+					}
+				}
+			}
+			fmt.Println("\n---------------------------------------------")
+		}
+		fmt.Println("\nComando 'prova generate' concluído com lógica de simulação.")
+	},
+}
+
+// Helper para verificar se um slice de strings contém um valor específico (case-insensitive)
+func contains(slice []string, val string) bool {
+	for _, item := range slice {
+		if strings.EqualFold(item, val) {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper para verificar se um slice de strings contém qualquer um dos valores de outro slice (case-insensitive)
+func containsAny(slice []string, vals []string) bool {
+	for _, item := range slice {
+		for _, val := range vals {
+			if strings.EqualFold(item, val) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Helper para encontrar uma questão por ID em uma lista de questões (simulação)
+func findQuestionByID(id string, questions []models.Question) *models.Question {
+	for _, q := range questions {
+		if q.ID == id {
+			return &q
+		}
+	}
+	return nil
+}
+
+
+func init() {
+	ProvaCmd.AddCommand(generateCmd)
+
+	// Flags para o comando generate (baseado em docs/specifications/prova_command_spec.md):
+	generateCmd.Flags().StringP("title", "t", "", "Título da prova (obrigatório)")
+	generateCmd.MarkFlagRequired("title")
+
+	generateCmd.Flags().StringP("subject", "s", "", "Disciplina principal da prova (obrigatório)")
+	generateCmd.MarkFlagRequired("subject")
+
+	generateCmd.Flags().StringSlice("topic", []string{}, "Tópicos/assuntos a serem incluídos na prova (opcional)")
+	generateCmd.Flags().StringSlice("difficulty", []string{}, "Níveis de dificuldade das questões (ex: facil, medio, dificil) (opcional)")
+	generateCmd.Flags().StringSlice("type", []string{}, "Tipos de questões (ex: multipla_escolha, dissertativa) (opcional)")
+	generateCmd.Flags().StringSlice("tag", []string{}, "Tags para filtrar questões (opcional)")
+
+	generateCmd.Flags().Int("num-questions", 0, "Número total de questões a serem selecionadas (opcional)")
+	generateCmd.Flags().Int("num-easy", 0, "Número de questões fáceis (opcional, usado se num-questions não for especificado)")
+	generateCmd.Flags().Int("num-medium", 0, "Número de questões médias (opcional, usado se num-questions não for especificado)")
+	generateCmd.Flags().Int("num-hard", 0, "Número de questões difíceis (opcional, usado se num-questions não for especificado)")
+
+	generateCmd.Flags().Bool("allow-duplicates", false, "Permitir questões duplicadas (opcional, padrão: false)")
+	generateCmd.Flags().Bool("randomize-order", false, "Randomizar a ordem das questões na prova (opcional, padrão: false)")
+
+	generateCmd.Flags().StringP("output-file", "o", "", "Caminho do arquivo para salvar a prova gerada (opcional)")
+	generateCmd.Flags().String("output-format", "txt", "Formato do arquivo de saída (ex: txt, json, pdf) (opcional, padrão: txt)")
+	generateCmd.Flags().StringP("instructions", "i", "", "Instruções gerais para a prova (opcional)")
+
+	// Placeholder flags from original template, kept for reference, might be used differently or removed
+	// generateCmd.Flags().StringArrayP("question-ids", "q", []string{}, "Lista de IDs de questões a serem incluídas") // This might be an alternative way to specify questions
+	// generateCmd.Flags().StringToStringP("layout-options", "l", map[string]string{}, "Opções de formatação (ex: columns=2,header='Nome da Escola')")
+	// generateCmd.Flags().Int64("randomization-seed", 0, "Semente para randomização da ordem das questões/alternativas")
+}

--- a/cmd/prova/generate_test.go
+++ b/cmd/prova/generate_test.go
@@ -1,0 +1,252 @@
+package prova
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	// Assuming ProvaCmd is the root for 'prova' subcommands.
+	// If generateCmd is added to a different root, that root should be used.
+	// For this test, we will assume ProvaCmd is correctly set up in init functions.
+	// "vickgenda-cli/cmd" // If ProvaCmd is added to a global rootCmd in `cmd`
+)
+
+// executeProvaCommand executes the 'prova generate' command with given arguments
+// and returns the stdout/stderr output and any error.
+func executeProvaCommand(args ...string) (string, error) {
+	// Reset ProvaCmd for each test run to ensure clean state for flags, etc.
+	// This might involve re-initializing ProvaCmd or its subcommands if they are modified by execution.
+	// For simplicity, we'll assume ProvaCmd and its subcommands are available as defined.
+	// If ProvaCmd is not directly executable or holds state, this might need adjustment.
+	// e.g., rootCmd := cmd.NewRootCmd(); rootCmd.AddCommand(ProvaCmd) and execute rootCmd.
+
+	// If testing generateCmd directly:
+	// cmdToTest := generateCmd
+	// If testing via the main ProvaCmd:
+	cmdToTest := ProvaCmd // ProvaCmd should have generateCmd added to it.
+
+	b := new(bytes.Buffer)
+	cmdToTest.SetOut(b)
+	cmdToTest.SetErr(b)
+
+	// Prepend "generate" to the args for ProvaCmd
+	fullArgs := append([]string{"generate"}, args...)
+	cmdToTest.SetArgs(fullArgs)
+
+	// Before executing, ensure any persistent flags or states are reset if necessary.
+	// For generateCmd, flags are defined in its init(), so they should be fresh unless
+	// cobra holds state across SetArgs/Execute calls on the same Command instance.
+	// It's safer to re-create command instances for each test if state is an issue.
+	// However, for this scope, we'll use the existing ProvaCmd.
+
+	err := cmdToTest.Execute()
+	return b.String(), err
+}
+
+// TestProvaGenerateRequiredFlags checks if errors are reported for missing required flags.
+func TestProvaGenerateRequiredFlags(t *testing.T) {
+	// Test without --title
+	output, err := executeProvaCommand("--subject", "Matemática")
+	if err == nil {
+		t.Errorf("Expected error when --title is missing, got nil")
+	}
+	// Cobra typically prints to stderr (which we captured) and returns an error.
+	// The exact error message depends on Cobra's internals but usually mentions the missing flag.
+	if !strings.Contains(output, "flag pflag: title has been marked as required") && !strings.Contains(output, "Error: required flag(s) \"title\" not set") {
+		// Adjusted to check for common variations of Cobra's error message
+		t.Errorf("Expected output to contain missing title flag error, got: %s", output)
+	}
+
+	// Test without --subject
+	output, err = executeProvaCommand("--title", "Prova Teste")
+	if err == nil {
+		t.Errorf("Expected error when --subject is missing, got nil")
+	}
+	if !strings.Contains(output, "flag pflag: subject has been marked as required") && !strings.Contains(output, "Error: required flag(s) \"subject\" not set") {
+		t.Errorf("Expected output to contain missing subject flag error, got: %s", output)
+	}
+}
+
+// TestProvaGenerateBasicGeneration tests basic successful generation of a prova.
+func TestProvaGenerateBasicGeneration(t *testing.T) {
+	// Assuming sampleQuestions in generate.go has a "Matemática" "fácil" question.
+	args := []string{
+		"--title", "Prova de Matemática Simples",
+		"--subject", "Matemática", // This subject must exist in sampleQuestions
+		"--num-questions", "1",    // Requesting one question
+		// "--difficulty", "fácil", // This might be too specific if not enough easy math questions
+	}
+	output, err := executeProvaCommand(args...)
+	if err != nil {
+		t.Fatalf("Expected no error for basic generation, got: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Prova Gerada (Objeto models.Test)") {
+		t.Errorf("Output does not contain confirmation of models.Test object creation. Got: %s", output)
+	}
+	if !strings.Contains(output, "ID:") { // Check for part of the models.Test output
+		t.Errorf("Output does not seem to print the Test object. Got: %s", output)
+	}
+	if !strings.Contains(output, "Título: Prova de Matemática Simples") {
+		t.Errorf("Output does not contain the correct Test Title. Got: %s", output)
+	}
+	// Check if at least one question is mentioned in the "Visualização da Prova" part
+	if !strings.Contains(output, "Questão 1 (ID: q") {
+		t.Errorf("Output does not seem to list any question for the test. Got: %s", output)
+	}
+}
+
+// TestProvaGenerateFilteringBySubject tests filtering questions by subject.
+func TestProvaGenerateFilteringBySubject(t *testing.T) {
+	// Test with a subject that should yield questions
+	argsMath := []string{
+		"--title", "Prova de Matemática",
+		"--subject", "Matemática", // Assuming "Matemática" questions exist
+		"--num-questions", "2",
+	}
+	outputMath, errMath := executeProvaCommand(argsMath...)
+	if errMath != nil {
+		t.Fatalf("Error during 'Matemática' test generation: %v\nOutput: %s", errMath, outputMath)
+	}
+	if !strings.Contains(outputMath, "Disciplina: Matemática") {
+		t.Errorf("Expected test subject to be 'Matemática', got different in output: %s", outputMath)
+	}
+	// Count occurrences of "Questão " to see how many questions were listed
+	// This is a bit fragile but works for simulation.
+	if strings.Count(outputMath, "Questão ") < 1 && !strings.Contains(outputMath, "Nenhuma questão encontrada") {
+		// Allow for 0 if no questions match, but then the "Nenhuma questão" message should be there.
+		t.Errorf("Expected at least one question for 'Matemática' or 'Nenhuma questão encontrada' message. Got: %s", outputMath)
+	}
+
+
+	// Test with a subject that should yield no questions from the sample set
+	argsNonExistent := []string{
+		"--title", "Prova de Astronomia",
+		"--subject", "Astronomia", // Assuming "Astronomia" has no questions in sampleQuestions
+	}
+	outputNonExistent, _ := executeProvaCommand(argsNonExistent...) // Error is expected due to no questions
+	if !strings.Contains(outputNonExistent, "Nenhuma questão encontrada com os critérios especificados") {
+		t.Errorf("Expected 'Nenhuma questão encontrada' message for 'Astronomia', got: %s", outputNonExistent)
+	}
+}
+
+// TestProvaGenerateNumQuestionsFlag tests the --num-questions and difficulty-specific num flags.
+func TestProvaGenerateNumQuestionsFlag(t *testing.T) {
+	// Test --num-questions
+	argsTotal := []string{
+		"--title", "Prova de 3 Questões",
+		"--subject", "Matemática", // Ensure enough math questions exist in sample
+		"--num-questions", "3",
+	}
+	outputTotal, errTotal := executeProvaCommand(argsTotal...)
+	if errTotal != nil {
+		t.Fatalf("Error generating test with --num-questions 3: %v\nOutput: %s", errTotal, outputTotal)
+	}
+	// A simple way to check number of questions is to count "Questão X:"
+	// This depends on the output format of the simulation.
+	numGenerated := strings.Count(outputTotal, "\nQuestão ") // Assuming each question starts on a new line like this
+	if numGenerated != 3 {
+		// It's possible fewer are generated if not enough match criteria.
+		// The simulation logic tries to get up to num-questions.
+		// We need to inspect sampleQuestions and filtering logic to be sure.
+		// For now, we expect it to try and succeed if questions are available.
+		// Check if "Total de questões filtradas inicialmente" is less than 3, or if selection failed.
+		if !strings.Contains(outputTotal, "Não foi possível selecionar questões") && !strings.Contains(outputTotal, "Nenhuma questão encontrada") {
+			// If it didn't explicitly fail to select, it should have 3 or fewer if sample is small
+			if numGenerated > 3 {
+				t.Errorf("Expected up to 3 questions, got %d. Output: %s", numGenerated, outputTotal)
+			} else if numGenerated == 0 && len(sampleQuestions) > 0 { // if sample has questions, 0 is unexpected unless filters are too strict
+                 // This check is tricky without knowing the exact state of sampleQuestions and filters applied by default.
+                 // For this test, let's assume there are at least 3 generic math questions.
+                 // t.Logf("Warning: Expected 3 questions, got %d. This might be due to insufficient matching sample questions for 'Matemática'. Output: %s", numGenerated, outputTotal)
+            }
+		}
+	}
+
+	// Test --num-easy, --num-medium, --num-hard (assuming sample data has these)
+	// This is more complex to assert precisely without deeper inspection of sample data state
+	// and the selection algorithm's behavior when exact counts aren't met.
+	// For now, a basic check that it runs:
+	argsDifficulty := []string{
+		"--title", "Prova por Dificuldade",
+		"--subject", "Matemática",
+		"--num-easy", "1",
+		"--num-medium", "1",
+		// "--num-hard", "0", // Let's assume there's at least one easy and one medium math question
+	}
+	outputDifficulty, errDiff := executeProvaCommand(argsDifficulty...)
+	if errDiff != nil {
+		t.Fatalf("Error generating test with difficulty numbers: %v\nOutput: %s", errDiff, outputDifficulty)
+	}
+	if !strings.Contains(outputDifficulty, "Prova Gerada") {
+		t.Errorf("Expected successful generation for difficulty specific numbers. Got: %s", outputDifficulty)
+	}
+	// A more robust test would check the actual difficulties of the output questions.
+}
+
+
+// TestProvaGenerateRandomization tests if randomization seed is set.
+func TestProvaGenerateRandomization(t *testing.T) {
+	args := []string{
+		"--title", "Prova Randomizada",
+		"--subject", "Matemática",
+		"--num-questions", "2", // Need at least 2 to see order effects, though we only check seed
+		"--randomize-order",
+	}
+	output, err := executeProvaCommand(args...)
+	if err != nil {
+		t.Fatalf("Error during randomized test generation: %v\nOutput: %s", err, output)
+	}
+	// Check if the RandomizationSeed is non-zero in the models.Test output
+	// Example output: RandomizationSeed:1234567890
+	if !strings.Contains(output, "RandomizationSeed:") || strings.Contains(output, "RandomizationSeed:0") {
+		// It's possible seed is 0 if no questions were selected, or if randomization didn't run.
+		// Check if questions were actually generated.
+		if strings.Contains(output, "Questão 1") { // implies questions were generated
+			t.Errorf("Expected a non-zero RandomizationSeed in output when --randomize-order is used and questions are generated, got: %s", output)
+		}
+	}
+}
+
+// TestProvaGenerateOutputFileSimulation tests the output message for file saving.
+func TestProvaGenerateOutputFileSimulation(t *testing.T) {
+	args := []string{
+		"--title", "Prova para Arquivo",
+		"--subject", "Geografia", // Assuming geography questions exist
+		"--num-questions", "1",
+		"--output-file", "minha_prova.txt",
+	}
+	output, err := executeProvaCommand(args...)
+	if err != nil {
+		t.Fatalf("Error during test with --output-file: %v\nOutput: %s", err, output)
+	}
+
+	expectedMsg := "Simulando salvamento da prova em: minha_prova.txt"
+	if !strings.Contains(output, expectedMsg) {
+		t.Errorf("Expected output to contain '%s', got: %s", expectedMsg, output)
+	}
+	// Also check that the full text rendering of the prova is NOT present
+	if strings.Contains(output, "--- Visualização da Prova (Formato Texto Simples) ---") {
+		t.Errorf("Expected full prova visualization to be absent when --output-file is used. Got: %s", output)
+	}
+}
+
+// TODO: Add more tests:
+// - Test for --allow-duplicates (if logic becomes non-trivial)
+// - Test for specific question selection using more filters (tags, topics, type)
+// - Test edge cases for num-questions (e.g., asking for more questions than available)
+// - Test interaction between num-questions and num-easy/medium/hard
+// - Test with empty sampleQuestions to ensure graceful handling.
+// - Test --instructions flag.
+
+// Note: To properly test randomization effects on order, one might need to run the command
+// multiple times with the same explicit seed (if that flag is added) and compare outputs,
+// or run with --randomize-order and check if two identical calls produce different question orders
+// (statistically, they should if there are enough questions to shuffle).
+// For now, checking the RandomizationSeed field is a simpler proxy.
+
+// To make tests more robust against changes in sample data, consider:
+// 1. Defining test-specific sample data within the test file.
+// 2. Modifying `generateCmd` or its underlying logic to accept a question source (e.g., a slice)
+//    that can be injected during tests. This is a common pattern for better unit testing.
+// For this subtask, we rely on the global `sampleQuestions` in `generate.go`.

--- a/cmd/prova/list.go
+++ b/cmd/prova/list.go
@@ -1,0 +1,159 @@
+package prova
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"vickgenda-cli/internal/models" // Assuming models.Test is defined here
+)
+
+// Sample tests for simulation
+var sampleGeneratedProvas = []models.Test{
+	{ID: "prova123", Title: "Prova de Matemática Básica", Subject: "Matemática", CreatedAt: time.Now().Add(-24 * time.Hour), QuestionIDs: []string{"q1", "q2", "q6"}, Instructions: "Leia com atenção."},
+	{ID: "prova456", Title: "Avaliação de História do Brasil", Subject: "História", CreatedAt: time.Now().Add(-48 * time.Hour), QuestionIDs: []string{"q3", "q7"}, Instructions: "Responda de forma clara."},
+	{ID: "prova789", Title: "Teste Surpresa de Geografia", Subject: "Geografia", CreatedAt: time.Now(), QuestionIDs: []string{"q5"}},
+	{ID: "prova101", Title: "Prova Avançada de Cálculo", Subject: "Matemática", CreatedAt: time.Now().Add(-72 * time.Hour), QuestionIDs: []string{"q4", "q10", "q8"}, Instructions: "Justifique suas respostas."},
+	{ID: "prova202", Title: "Revisão de Tópicos Matemáticos", Subject: "Matemática", CreatedAt: time.Now().Add(-12 * time.Hour), QuestionIDs: []string{"q1", "q8", "q9"}, Instructions: "Boa sorte!"},
+}
+
+// listCmd representa o comando para listar provas geradas.
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lista provas geradas",
+	Long:  `Lista todas as provas que foram geradas e estão armazenadas no sistema.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Executando o comando 'prova list' com lógica de simulação...")
+
+		// Recuperar valores das flags
+		subjectFilter, _ := cmd.Flags().GetString("subject")
+		limit, _ := cmd.Flags().GetInt("limit")
+		page, _ := cmd.Flags().GetInt("page")
+		sortBy, _ := cmd.Flags().GetString("sort-by")
+		order, _ := cmd.Flags().GetString("order")
+
+		// 1. Filtrar provas
+		var filteredProvas []models.Test
+		if subjectFilter != "" {
+			for _, p := range sampleGeneratedProvas {
+				if strings.EqualFold(p.Subject, subjectFilter) {
+					filteredProvas = append(filteredProvas, p)
+				}
+			}
+		} else {
+			filteredProvas = make([]models.Test, len(sampleGeneratedProvas))
+			copy(filteredProvas, sampleGeneratedProvas)
+		}
+
+		if len(filteredProvas) == 0 {
+			fmt.Printf("Nenhuma prova encontrada com o filtro de disciplina: '%s'.\n", subjectFilter)
+			return
+		}
+
+		// 2. Validar e aplicar ordenação
+		validSortBy := []string{"created_at", "title", "subject"}
+		isValidSortBy := false
+		for _, valid := range validSortBy {
+			if sortBy == valid {
+				isValidSortBy = true
+				break
+			}
+		}
+		if !isValidSortBy {
+			fmt.Printf("Critério de ordenação inválido: '%s'. Usando 'created_at'.\n", sortBy)
+			sortBy = "created_at"
+		}
+		if order != "asc" && order != "desc" {
+			fmt.Printf("Ordem inválida: '%s'. Usando 'desc'.\n", order)
+			order = "desc"
+		}
+
+		sort.Slice(filteredProvas, func(i, j int) bool {
+			p1 := filteredProvas[i]
+			p2 := filteredProvas[j]
+			var less bool
+			switch sortBy {
+			case "title":
+				less = strings.ToLower(p1.Title) < strings.ToLower(p2.Title)
+			case "subject":
+				less = strings.ToLower(p1.Subject) < strings.ToLower(p2.Subject)
+			case "created_at":
+				less = p1.CreatedAt.Before(p2.CreatedAt)
+			default: // Should not happen due to validation
+				less = p1.CreatedAt.Before(p2.CreatedAt)
+			}
+			if order == "desc" {
+				return !less
+			}
+			return less
+		})
+
+		// 3. Aplicar Paginação
+		totalProvas := len(filteredProvas)
+		if limit <= 0 { // Default limit if not positive
+			limit = 10
+		}
+		if page <= 0 { // Default page if not positive
+			page = 1
+		}
+		startIndex := (page - 1) * limit
+		endIndex := startIndex + limit
+
+		if startIndex >= totalProvas {
+			fmt.Printf("Página %d fora do alcance. Total de provas: %d (limite por página: %d).\n", page, totalProvas, limit)
+			fmt.Println("Nenhuma prova para exibir nesta página.")
+			return
+		}
+		if endIndex > totalProvas {
+			endIndex = totalProvas
+		}
+
+		provasPaginadas := filteredProvas[startIndex:endIndex]
+		totalPages := (totalProvas + limit - 1) / limit
+
+
+		// 4. Exibir Resultados
+		fmt.Printf("\n--- Lista de Provas Geradas (Página %d de %d) ---\n", page, totalPages)
+		fmt.Println("----------------------------------------------------------------------------------------------------")
+		fmt.Printf("%-10s | %-35s | %-15s | %-20s | %s\n", "ID", "Título", "Disciplina", "Data de Criação", "Nº Questões")
+		fmt.Println("----------------------------------------------------------------------------------------------------")
+
+		if len(provasPaginadas) == 0 { // Should be caught by startIndex check, but good for safety
+			fmt.Println("Nenhuma prova encontrada para os critérios especificados.")
+		} else {
+			for _, p := range provasPaginadas {
+				fmt.Printf("%-10s | %-35s | %-15s | %-20s | %d\n",
+					p.ID,
+					truncateString(p.Title, 33),
+					truncateString(p.Subject, 13),
+					p.CreatedAt.Format("02/01/2006 15:04:05"),
+					len(p.QuestionIDs))
+			}
+		}
+		fmt.Println("----------------------------------------------------------------------------------------------------")
+		fmt.Printf("Exibindo %d de %d provas. Ordenado por: %s (%s).\n", len(provasPaginadas), totalProvas, sortBy, order)
+
+		fmt.Println("\nComando 'prova list' concluído com lógica de simulação.")
+	},
+}
+
+// Helper para truncar string e adicionar "..." se for maior que o comprimento máximo
+func truncateString(s string, maxLength int) string {
+	if len(s) > maxLength {
+		return s[:maxLength-3] + "..."
+	}
+	return s
+}
+
+
+func init() {
+	ProvaCmd.AddCommand(listCmd)
+	// Flags para o comando list (baseado em docs/specifications/prova_command_spec.md):
+	listCmd.Flags().StringP("subject", "s", "", "Filtrar provas por disciplina (opcional)")
+	listCmd.Flags().IntP("limit", "l", 10, "Limitar o número de provas listadas por página (opcional, padrão: 10)")
+	listCmd.Flags().IntP("page", "p", 1, "Número da página para exibir (opcional, padrão: 1)")
+	listCmd.Flags().String("sort-by", "created_at", "Critério de ordenação (ex: created_at, title, subject) (opcional, padrão: created_at)")
+	listCmd.Flags().String("order", "desc", "Ordem de classificação (asc ou desc) (opcional, padrão: desc)")
+}

--- a/cmd/prova/list_test.go
+++ b/cmd/prova/list_test.go
@@ -1,0 +1,269 @@
+package prova
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+	// No direct cobra import needed here if ProvaCmd is globally accessible
+	// "vickgenda-cli/internal/models" // Not directly used in test logic, but command uses it
+)
+
+// executeProvaListCommand executes the 'prova list' command with given arguments
+// and returns the stdout/stderr output and any error.
+func executeProvaListCommand(args ...string) (string, error) {
+	cmdToTest := ProvaCmd // ProvaCmd should have listCmd added to it.
+
+	b := new(bytes.Buffer)
+	cmdToTest.SetOut(b)
+	cmdToTest.SetErr(b)
+
+	fullArgs := append([]string{"list"}, args...)
+	cmdToTest.SetArgs(fullArgs)
+
+	// Reset flags for listCmd to default values before each execution.
+	// This is important because Cobra commands retain flag values across executions.
+	// listCmd is a child of ProvaCmd.
+	// We need to find listCmd and reset its flags.
+	// This assumes listCmd is already added to ProvaCmd.
+	// A more robust way might be to re-initialize ProvaCmd and its subcommands for each test.
+	var listCmdInstance *cobra.Command
+	for _, cmd := range ProvaCmd.Commands() {
+		if cmd.Name() == "list" {
+			listCmdInstance = cmd
+			break
+		}
+	}
+	if listCmdInstance != nil {
+		listCmdInstance.Flags().Visit(func(f *pflag.Flag) {
+			f.Value.Set(f.DefValue) // Reset to default value
+		})
+	}
+
+
+	err := cmdToTest.Execute()
+	return b.String(), err
+}
+
+// TestProvaListDefault tests the default output of 'prova list'.
+func TestProvaListDefault(t *testing.T) {
+	// Reset sample data to its original state before this test block
+	originalSampleProvas := make([]models.Test, len(sampleGeneratedProvas))
+	copy(originalSampleProvas, sampleGeneratedProvas)
+	t.Cleanup(func() {
+		sampleGeneratedProvas = originalSampleProvas
+	})
+
+
+	output, err := executeProvaListCommand()
+	if err != nil {
+		t.Fatalf("Expected no error for default list, got: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "ID         | Título                              | Disciplina      | Data de Criação      | Nº Questões") {
+		t.Errorf("Output does not contain the expected table header. Got: %s", output)
+	}
+
+	// Check for a known entry from sampleGeneratedProvas (e.g., "prova123")
+	// This depends on the sample data in list.go
+	if !strings.Contains(output, "prova123") {
+		t.Errorf("Output does not contain expected sample test ID 'prova123'. Got: %s", output)
+	}
+	if !strings.Contains(output, "prova456") {
+		t.Errorf("Output does not contain expected sample test ID 'prova456'. Got: %s", output)
+	}
+
+	// Default sort is created_at desc.
+	// sampleGeneratedProvas:
+	// {ID: "prova789", Title: "Teste Surpresa de Geografia", ..., CreatedAt: time.Now()}
+	// {ID: "prova202", Title: "Revisão de Tópicos Matemáticos", ..., CreatedAt: time.Now().Add(-12 * time.Hour)}
+	// {ID: "prova123", Title: "Prova de Matemática Básica", ..., CreatedAt: time.Now().Add(-24 * time.Hour)}
+	// {ID: "prova456", Title: "Avaliação de História do Brasil", ..., CreatedAt: time.Now().Add(-48 * time.Hour)}
+	// {ID: "prova101", Title: "Prova Avançada de Cálculo", ..., CreatedAt: time.Now().Add(-72 * time.Hour)}
+
+	// So, "prova789" should appear before "prova123"
+	idx789 := strings.Index(output, "prova789")
+	idx123 := strings.Index(output, "prova123")
+
+	if idx789 == -1 || idx123 == -1 || idx789 > idx123 {
+		t.Errorf("Default sort order (created_at desc) seems incorrect or items not found. 'prova789' index: %d, 'prova123' index: %d. Output:\n%s", idx789, idx123, output)
+	}
+}
+
+// TestProvaListFilterBySubject tests filtering by subject.
+func TestProvaListFilterBySubject(t *testing.T) {
+	originalSampleProvas := make([]models.Test, len(sampleGeneratedProvas))
+	copy(originalSampleProvas, sampleGeneratedProvas)
+	t.Cleanup(func() {
+		sampleGeneratedProvas = originalSampleProvas
+	})
+
+	// Filter by "História"
+	output, err := executeProvaListCommand("--subject", "História")
+	if err != nil {
+		t.Fatalf("Error filtering by subject 'História': %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "prova456") { // Belongs to História
+		t.Errorf("Expected 'prova456' (História) in output, got: %s", output)
+	}
+	if strings.Contains(output, "prova123") { // Belongs to Matemática
+		t.Errorf("Did not expect 'prova123' (Matemática) in 'História' filtered output. Got: %s", output)
+	}
+
+	// Filter by a subject with no tests
+	outputNoMatch, errNoMatch := executeProvaListCommand("--subject", "QuímicaAvançada")
+	if errNoMatch != nil {
+		// The command itself doesn't error, it just prints a message.
+		// Depending on implementation, errNoMatch might be nil.
+		// t.Fatalf("Error filtering by subject 'QuímicaAvançada': %v\nOutput: %s", errNoMatch, outputNoMatch)
+	}
+	if !strings.Contains(outputNoMatch, "Nenhuma prova encontrada com o filtro de disciplina: 'QuímicaAvançada'") &&
+	   !strings.Contains(outputNoMatch, "Nenhuma prova encontrada para os critérios especificados.") { // Fallback message if pagination results in none
+		t.Errorf("Expected 'Nenhuma prova encontrada' message for 'QuímicaAvançada', got: %s", outputNoMatch)
+	}
+}
+
+// TestProvaListSort tests sorting functionality.
+func TestProvaListSort(t *testing.T) {
+	originalSampleProvas := make([]models.Test, len(sampleGeneratedProvas))
+	copy(originalSampleProvas, sampleGeneratedProvas)
+	t.Cleanup(func() {
+		sampleGeneratedProvas = originalSampleProvas
+	})
+
+	// Sort by title asc
+	// Titles: "Avaliação de História do Brasil" (prova456), "Prova Avançada de Cálculo" (prova101),
+	// "Prova de Matemática Básica" (prova123), "Revisão de Tópicos Matemáticos" (prova202), "Teste Surpresa de Geografia" (prova789)
+	output, err := executeProvaListCommand("--sort-by", "title", "--order", "asc")
+	if err != nil {
+		t.Fatalf("Error sorting by title asc: %v\nOutput: %s", err, output)
+	}
+
+	idxAvaliacao := strings.Index(output, "prova456") // Avaliação
+	idxProvaAvancada := strings.Index(output, "prova101") // Prova Avançada
+	idxProvaBasica := strings.Index(output, "prova123") // Prova de Matemática
+
+	if !(idxAvaliacao < idxProvaAvancada && idxProvaAvancada < idxProvaBasica) {
+		t.Errorf("Expected titles in ascending order. Got indices: Avaliação (%d), Prova Avançada (%d), Prova Básica (%d). Output:\n%s", idxAvaliacao, idxProvaAvancada, idxProvaBasica, output)
+	}
+
+	// Test invalid sort-by value (should default to created_at and print a message)
+	outputInvalidSort, _ := executeProvaListCommand("--sort-by", "invalidField")
+	if !strings.Contains(outputInvalidSort, "Critério de ordenação inválido: 'invalidField'. Usando 'created_at'.") {
+		t.Errorf("Expected warning for invalid sort-by value. Got: %s", outputInvalidSort)
+	}
+}
+
+// TestProvaListPagination tests pagination functionality.
+func TestProvaListPagination(t *testing.T) {
+	originalSampleProvas := make([]models.Test, len(sampleGeneratedProvas))
+	copy(originalSampleProvas, sampleGeneratedProvas)
+	t.Cleanup(func() {
+		sampleGeneratedProvas = originalSampleProvas
+	})
+
+	// Assuming at least 3 sample provas. Let's use the default sort (created_at desc)
+	// Prova IDs by created_at desc: prova789, prova202, prova123, prova456, prova101
+
+	// Page 1, Limit 1
+	outputP1L1, err := executeProvaListCommand("--limit", "1", "--page", "1")
+	if err != nil {
+		t.Fatalf("Error with limit 1 page 1: %v\nOutput: %s", err, outputP1L1)
+	}
+	if !strings.Contains(outputP1L1, "prova789") { // First item by created_at desc
+		t.Errorf("Expected 'prova789' on page 1 limit 1. Got: %s", outputP1L1)
+	}
+	if strings.Contains(outputP1L1, "prova202") {
+		t.Errorf("Did not expect 'prova202' on page 1 limit 1. Got: %s", outputP1L1)
+	}
+	if !strings.Contains(outputP1L1, "Página 1 de 5") { // Assuming 5 total sample items
+		t.Errorf("Page info incorrect for page 1 limit 1. Got: %s", outputP1L1)
+	}
+
+
+	// Page 2, Limit 1
+	outputP2L1, err := executeProvaListCommand("--limit", "1", "--page", "2")
+	if err != nil {
+		t.Fatalf("Error with limit 1 page 2: %v\nOutput: %s", err, outputP2L1)
+	}
+	if !strings.Contains(outputP2L1, "prova202") { // Second item
+		t.Errorf("Expected 'prova202' on page 2 limit 1. Got: %s", outputP2L1)
+	}
+	if strings.Contains(outputP2L1, "prova789") {
+		t.Errorf("Did not expect 'prova789' on page 2 limit 1. Got: %s", outputP2L1)
+	}
+	if !strings.Contains(outputP2L1, "Página 2 de 5") {
+		t.Errorf("Page info incorrect for page 2 limit 1. Got: %s", outputP2L1)
+	}
+
+	// Page out of bounds
+	outputOOB, _ := executeProvaListCommand("--limit", "1", "--page", "10") // Assuming only 5 sample items
+	if !strings.Contains(outputOOB, "Página 10 fora do alcance") && !strings.Contains(outputOOB, "Nenhuma prova para exibir nesta página.") {
+		t.Errorf("Expected 'Página fora do alcance' or 'Nenhuma prova para exibir' message for out-of-bounds page. Got: %s", outputOOB)
+	}
+}
+
+// TestProvaListCombinedFlags tests a combination of filtering, sorting, and pagination.
+func TestProvaListCombinedFlags(t *testing.T) {
+	originalSampleProvas := make([]models.Test, len(sampleGeneratedProvas))
+	copy(originalSampleProvas, sampleGeneratedProvas)
+	t.Cleanup(func() {
+		sampleGeneratedProvas = originalSampleProvas
+	})
+
+	// Filter by Matemática, sort by title asc, limit 1, page 1
+	// Matemática titles: "Prova Avançada de Cálculo" (prova101), "Prova de Matemática Básica" (prova123), "Revisão de Tópicos Matemáticos" (prova202)
+	// Sorted by title asc: "Prova Avançada de Cálculo" (prova101) should be first.
+	args := []string{
+		"--subject", "Matemática",
+		"--sort-by", "title",
+		"--order", "asc",
+		"--limit", "1",
+		"--page", "1",
+	}
+	output, err := executeProvaListCommand(args...)
+	if err != nil {
+		t.Fatalf("Error with combined flags: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "prova101") { // "Prova Avançada de Cálculo"
+		t.Errorf("Expected 'prova101' with combined flags. Got: %s", output)
+	}
+	if strings.Contains(output, "prova123") || strings.Contains(output, "prova202") {
+		t.Errorf("Did not expect other Matemática provas with limit 1. Got: %s", output)
+	}
+	// Total de provas (Matemática) = 3. TotalPages = (3+1-1)/1 = 3
+	if !strings.Contains(output, "Página 1 de 3") {
+		t.Errorf("Page info incorrect for combined flags. Expected 'Página 1 de 3'. Got: %s", output)
+	}
+}
+
+// Helper to count rows in the output table (excluding header)
+func countTableRows(output string) int {
+	lines := strings.Split(output, "\n")
+	count := 0
+	// Regex to match a line that seems like a data row (starts with an ID, has pipes)
+	// This is fragile and depends on the exact format.
+	// Example ID: prova123 (not just digits)
+	rowRegex := regexp.MustCompile(`^[a-zA-Z0-9]+ *\|`)
+	for _, line := range lines {
+		if rowRegex.MatchString(strings.TrimSpace(line)) {
+			count++
+		}
+	}
+	return count
+}
+
+// Note: The `sampleGeneratedProvas` is modified by some operations in `list.go` (e.g. sorting is in-place).
+// For robust tests, we should ensure this sample data is reset before each test or test group,
+// or the functions in list.go should operate on a copy.
+// Added t.Cleanup to reset sampleGeneratedProvas.
+// Also, `pflag` state can persist. Added reset for listCmd flags.
+
+// Import pflag for resetting flags
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"vickgenda-cli/internal/models"
+)

--- a/cmd/prova/prova.go
+++ b/cmd/prova/prova.go
@@ -1,0 +1,20 @@
+package prova
+
+import "github.com/spf13/cobra"
+
+// ProvaCmd representa o comando raiz para gerenciar provas.
+var ProvaCmd = &cobra.Command{
+	Use:   "prova",
+	Short: "Gerencia provas e avaliações",
+	Long:  `Permite gerar, listar, visualizar, deletar e exportar provas criadas a partir do banco de questões.`,
+}
+
+// Execute adiciona todos os comandos filhos ao comando raiz e define flags apropriadamente.
+// Esta é chamada por main.main(). Ela só precisa acontecer uma vez para o rootCmd.
+func Execute() error {
+	return ProvaCmd.Execute()
+}
+
+func init() {
+	// Aqui você pode adicionar inicializações, como flags globais para o comando prova.
+}

--- a/cmd/prova/view.go
+++ b/cmd/prova/view.go
@@ -1,0 +1,182 @@
+package prova
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"vickgenda-cli/internal/models"
+)
+
+// --- Reusing sample data structures (similar to list.go and generate.go) ---
+
+// Sample tests for simulation (can be shared or redefined if state is an issue)
+var viewSampleGeneratedProvas = []models.Test{
+	{ID: "prova123", Title: "Prova de Matemática Básica", Subject: "Matemática", CreatedAt: time.Now().Add(-24 * time.Hour), QuestionIDs: []string{"q1", "q2", "q6", "qMissing"}, Instructions: "Leia com atenção cada questão."},
+	{ID: "prova456", Title: "Avaliação de História do Brasil", Subject: "História", CreatedAt: time.Now().Add(-48 * time.Hour), QuestionIDs: []string{"q3", "q7"}, Instructions: "Responda de forma clara e objetiva."},
+	{ID: "prova789", Title: "Teste Surpresa de Geografia", Subject: "Geografia", CreatedAt: time.Now(), QuestionIDs: []string{"q5"}},
+}
+
+// Sample questions for simulation (can be shared or redefined)
+var viewSampleQuestions = []models.Question{
+	{ID: "q1", Subject: "Matemática", Text: "Quanto é 2+2?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"aritmética"}, Tags: []string{"básica"}, Options: []models.QuestionOption{{Text: "3", IsCorrect: false}, {Text: "4", IsCorrect: true}, {Text: "5", IsCorrect: false}}, CorrectAnswers: []string{"4"}},
+	{ID: "q2", Subject: "Matemática", Text: "Quanto é 5*8?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"aritmética"}, Tags: []string{"básica"}, Options: []models.QuestionOption{{Text: "30", IsCorrect: false}, {Text: "40", IsCorrect: true}, {Text: "35", IsCorrect: false}}, CorrectAnswers: []string{"40"}},
+	{ID: "q3", Subject: "História", Text: "Quem descobriu o Brasil?", Type: "dissertativa", Difficulty: "médio", Topics: []string{"descobrimentos"}, Tags: []string{"Brasil"}, CorrectAnswers: []string{"Pedro Álvares Cabral"}},
+	{ID: "q4", Subject: "Matemática", Text: "Qual a derivada de x^2?", Type: "dissertativa", Difficulty: "difícil", Topics: []string{"cálculo"}, Tags: []string{"avançada"}, CorrectAnswers: []string{"2x"}},
+	{ID: "q5", Subject: "Geografia", Text: "Qual a capital da França?", Type: "multipla_escolha", Difficulty: "fácil", Topics: []string{"europa"}, Tags: []string{"capitais"}, Options: []models.QuestionOption{{Text: "Londres", IsCorrect: false}, {Text: "Paris", IsCorrect: true}, {Text: "Madri", IsCorrect: false}}, CorrectAnswers: []string{"Paris"}},
+	{ID: "q6", Subject: "Matemática", Text: "Resolva a equação: x + 5 = 10", Type: "dissertativa", Difficulty: "fácil", Topics: []string{"algebra"}, Tags: []string{"equação"}, CorrectAnswers: []string{"x = 5"}},
+	{ID: "q7", Subject: "História", Text: "Em que ano começou a Segunda Guerra Mundial?", Type: "multipla_escolha", Difficulty: "médio", Topics: []string{"guerras mundiais"}, Tags: []string{"século XX"}, Options: []models.QuestionOption{{Text: "1939", IsCorrect: true}, {Text: "1941", IsCorrect: false}, {Text: "1945", IsCorrect: false}}, CorrectAnswers: []string{"1939"}},
+	{ID: "q8", Subject: "Matemática", Text: "Qual o valor de Pi (aproximado)?", Type: "multipla_escolha", Difficulty: "médio", Topics: []string{"geometria"}, Tags: []string{"constantes"}, Options: []models.QuestionOption{{Text: "3.14", IsCorrect: true}, {Text: "3.12", IsCorrect: false}, {Text: "3.16", IsCorrect: false}}, CorrectAnswers: []string{"3.14"}},
+}
+
+// Helper to find a Test by ID
+func findTestByID(id string, tests []models.Test) *models.Test {
+	for i := range tests {
+		if tests[i].ID == id {
+			return &tests[i]
+		}
+	}
+	return nil
+}
+
+// Helper to find a Question by ID
+func findViewQuestionByID(id string, questions []models.Question) *models.Question {
+	for i := range questions {
+		if questions[i].ID == id {
+			return &questions[i]
+		}
+	}
+	return nil
+}
+// --- End of sample data structures ---
+
+// viewCmd representa o comando para visualizar uma prova específica.
+var viewCmd = &cobra.Command{
+	Use:   "view <id_prova>",
+	Short: "Visualiza uma prova específica",
+	Long:  `Carrega e exibe os detalhes de uma prova específica identificada pelo seu ID.`,
+	Args:  cobra.ExactArgs(1), // Espera exatamente um argumento: o ID da prova.
+	Run: func(cmd *cobra.Command, args []string) {
+		provaID := args[0] // Already validated by cobra.ExactArgs(1)
+		showAnswers, _ := cmd.Flags().GetBool("show-answers")
+		outputFormat, _ := cmd.Flags().GetString("output-format")
+
+		fmt.Printf("Executando o comando 'prova view' para a Prova ID: %s (Formato: %s, Mostrar Respostas: %t)\n",
+			provaID, outputFormat, showAnswers)
+
+		// 1. Validar output-format (focando em 'txt')
+		if outputFormat != "txt" {
+			fmt.Printf("AVISO: Formato de saída '%s' ainda não é totalmente suportado. Exibindo em formato de texto.\n", outputFormat)
+			// outputFormat = "txt" // Forçar para txt se quisermos ser estritos
+		}
+
+		// 2. Encontrar a prova
+		prova := findTestByID(provaID, viewSampleGeneratedProvas)
+		if prova == nil {
+			fmt.Printf("Erro: Prova com ID '%s' não encontrada.\n", provaID)
+			return
+		}
+
+		// 3. Preparar para buscar questões
+		var fetchedQuestions []*models.Question
+		questionsFoundMap := make(map[string]*models.Question) // Para fácil acesso e evitar duplicatas se ID for repetido
+
+		fmt.Println("\n[Simulação] Buscando detalhes das questões da prova...")
+		for _, qID := range prova.QuestionIDs {
+			if _, exists := questionsFoundMap[qID]; exists { // Evitar buscar a mesma questão múltiplas vezes se ID estiver duplicado na prova
+				continue
+			}
+			question := findViewQuestionByID(qID, viewSampleQuestions)
+			if question != nil {
+				fetchedQuestions = append(fetchedQuestions, question)
+				questionsFoundMap[qID] = question
+			} else {
+				fmt.Printf("AVISO: Questão com ID '%s' listada na prova não foi encontrada no banco de questões de simulação.\n", qID)
+				// Adicionar um placeholder ou tratar como erro crítico dependendo do requisito
+				fetchedQuestions = append(fetchedQuestions, &models.Question{ID: qID, Text: fmt.Sprintf("Questão com ID '%s' não encontrada.", qID), Type: "desconhecido"})
+			}
+		}
+
+		// 4. Formatar e Exibir Saída (formato TXT)
+		fmt.Printf("\n--- Detalhes da Prova: %s ---\n", prova.Title)
+		fmt.Printf("ID da Prova: %s\n", prova.ID)
+		fmt.Printf("Disciplina: %s\n", prova.Subject)
+		fmt.Printf("Data de Criação: %s\n", prova.CreatedAt.Format("02/01/2006 15:04:05"))
+		if prova.Instructions != "" {
+			fmt.Printf("Instruções: %s\n", prova.Instructions)
+		}
+		if prova.RandomizationSeed > 0 {
+			fmt.Printf("Semente de Randomização: %d\n", prova.RandomizationSeed)
+		}
+		fmt.Println("------------------------------------")
+
+		if len(prova.QuestionIDs) == 0 {
+			fmt.Println("Esta prova não contém questões.")
+		} else {
+			fmt.Printf("\n--- Questões (%d) ---\n", len(prova.QuestionIDs))
+			for i, qID := range prova.QuestionIDs {
+				question := questionsFoundMap[qID] // Usar o mapa para pegar a questão na ordem correta
+				if question == nil { // Segurança, embora o loop anterior deva popular
+					fmt.Printf("\n%d. Questão ID '%s': [ERRO INTERNO - Detalhes não puderam ser carregados]\n", i+1, qID)
+					continue
+				}
+
+				fmt.Printf("\n%d. (ID: %s) %s\n", i+1, question.ID, question.Text)
+				fmt.Printf("   Tipo: %s, Dificuldade: %s, Tópicos: %s, Tags: %s\n",
+					question.Type, question.Difficulty, strings.Join(question.Topics, ", "), strings.Join(question.Tags, ", "))
+
+				if question.Type == "multipla_escolha" || question.Type == "verdadeiro_falso" { // Adaptar para "true_false" se existir
+					if len(question.Options) > 0 {
+						fmt.Println("   Opções:")
+						for j, opt := range question.Options {
+							prefix := fmt.Sprintf("     %c)", 'A'+j)
+							if showAnswers {
+								isCorrectOption := false
+								for _, correctAns := range question.CorrectAnswers {
+									// Assumindo que CorrectAnswers para múltipla escolha guarda o TEXTO da opção correta
+									if strings.EqualFold(opt.Text, correctAns) {
+										isCorrectOption = true
+										break
+									}
+								}
+								if isCorrectOption {
+									prefix += " [*]" // Marcador para resposta correta
+								} else {
+									prefix += " [ ]"
+								}
+							}
+							fmt.Printf("%s %s\n", prefix, opt.Text)
+						}
+					} else {
+						fmt.Println("   AVISO: Questão de múltipla escolha sem opções definidas.")
+					}
+				}
+
+				if showAnswers {
+					if len(question.CorrectAnswers) > 0 {
+						// Para dissertativas, ou para mostrar explicitamente a(s) resposta(s) correta(s)
+						// mesmo para múltipla escolha (além do marcador [*])
+						if question.Type == "dissertativa" || (question.Type == "multipla_escolha" && len(question.Options) == 0) {
+							fmt.Printf("   Resposta(s) Correta(s): %s\n", strings.Join(question.CorrectAnswers, " | "))
+						} else if question.Type == "multipla_escolha" && len(question.Options) > 0 {
+							// Já mostrado com [*], mas pode adicionar um sumário se quiser
+							// fmt.Printf("   Gabarito (texto): %s\n", strings.Join(question.CorrectAnswers, " | "))
+						}
+					} else {
+						fmt.Println("   AVISO: Resposta(s) correta(s) não disponível(is) para esta questão.")
+					}
+				}
+			}
+		}
+		fmt.Println("\n------------------------------------")
+		fmt.Println("\nComando 'prova view' concluído com lógica de simulação.")
+	},
+}
+
+func init() {
+	ProvaCmd.AddCommand(viewCmd)
+	// Flags para o comando view (baseado em docs/specifications/prova_command_spec.md):
+	viewCmd.Flags().BoolP("show-answers", "a", false, "Mostrar respostas das questões na visualização (opcional, padrão: false)")
+	viewCmd.Flags().StringP("output-format", "f", "txt", "Formato de saída para visualização (ex: txt, json, markdown) (opcional, padrão: txt)")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os" // Required for os.Exit
 
 	"vickgenda-cli/cmd/bancoq"       // Direct import for adding command
+	"vickgenda-cli/cmd/prova"        // Import for prova.ProvaCmd
 	vickgendamain "vickgenda-cli/cmd/vickgenda" // Import for GetMainRootCmd
 	"vickgenda-cli/internal/db"      // Import for db.InitDB
 )
@@ -21,6 +22,7 @@ func init() {
 
 	// Add commands previously managed by this package's rootCmd
 	mainRootCmd.AddCommand(bancoq.BancoqCmd)
+	mainRootCmd.AddCommand(prova.ProvaCmd)
 	// If there were other commands added to the old rootCmd in this package, add them here.
 	// For example:
 	// mainRootCmd.AddCommand(anotherCmdFromThisPackage)

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -1,0 +1,27 @@
+package models
+
+import "time"
+
+// Test representa uma prova no sistema.
+// Em contextos de documentação ou comentários, pode ser referida como Prova.
+type Test struct {
+	// ID é o identificador único da prova.
+	ID string
+	// Title é o título da prova.
+	Title string
+	// Subject é a disciplina principal da prova.
+	Subject string
+	// CreatedAt é a data de criação da prova.
+	CreatedAt time.Time
+	// Instructions são as instruções gerais para a prova.
+	Instructions string
+	// QuestionIDs é uma lista ordenada dos IDs das questões incluídas na prova.
+	QuestionIDs []string
+	// LayoutOptions são opções de formatação para a prova.
+	// Exemplo: "columns": "2", "header": "School Name".
+	// Utiliza um mapa para flexibilidade.
+	LayoutOptions map[string]string
+	// RandomizationSeed é a semente utilizada se a ordem das questões ou alternativas foi randomizada.
+	// Guardar a semente permite reproduzir a randomização.
+	RandomizationSeed int64
+}


### PR DESCRIPTION
feat(prova): Implement 'prova' module structure, core logic, and initial tests

This commit introduces the 'prova' module for managing tests/exams.

Key changes include:

1.  **New `models.Test` Struct:**
    *   Defined in `internal/models/test.go`, this struct holds metadata for
        generated tests, such as ID, title, subject, question IDs, etc.

2.  **`prova` Command CLI Structure:**
    *   Created the `cmd/prova/` directory with files for the main `prova`
        command and its subcommands: `generate`, `list`, `view`, `delete`,
        and `export`.
    *   Implemented Cobra command definitions, flags, and argument parsing
        for each subcommand as per specifications.
    *   Registered the `prova` command with the root application command.

3.  **Simulated Core Logic for `prova` Subcommands:**
    *   `generate`: Implemented logic to filter and select questions from a
        sample dataset based on various criteria (subject, topic, difficulty,
        number), create a `models.Test` object, and simulate its output
        (console or file). Includes basic randomization.
    *   `list`: Implemented logic to filter, sort, and paginate a list of
        sample `models.Test` objects and display them in a formatted table.
    *   `view`: Implemented logic to retrieve a sample `models.Test` and its
        associated sample questions by ID, and display the formatted content,
        optionally showing answers.
    *   `delete`: Implemented logic to remove a sample `models.Test` by ID,
        including an interactive confirmation step (unless `--force` is used).
    *   `export`: Implemented logic to retrieve a sample `models.Test`, format
        its content, and simulate exporting it to a specified file.

4.  **Unit Tests for `prova` Subcommands (Initial Set):**
    *   `cmd/prova/generate_test.go`: Contains tests for flag validation,
        basic generation, filtering, question count parameters, randomization
        simulation, and output file simulation for the `generate` command.
    *   `cmd/prova/list_test.go`: Contains tests for default listing,
        filtering by subject, sorting by various criteria, and pagination
        for the `list` command.

All core logic currently operates on in-memory sample data for simulation purposes, allowing for testing of the command structures and flow before integration with actual database backends.