### PR TITLE
Implementa a lógica central do bancoq (Squad 5)

### DIFF
--- a/cmd/bancoq/add.go
+++ b/cmd/bancoq/add.go
@@ -17,118 +17,164 @@ import (
 var bancoqAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Adiciona uma nova questão ao banco",
-	Long:  `Permite adicionar uma nova questão ao banco de questões. Pode ser usado de forma interativa, solicitando cada campo, ou de forma não-interativa através de flags.`,
-	Run:   runAddQuestion,
+	Long: `Permite adicionar uma nova questão ao banco de questões.
+Pode ser usado de forma interativa, solicitando cada campo, ou de forma não-interativa através de flags.
+Exemplo não-interativo:
+  vickgenda bancoq add --subject "Matemática" --topic "Álgebra" --difficulty "medium" --type "multiple_choice" --question "Qual o valor de x em 2x = 4?" --option "x = 1" --option "x = 2" --answer "x = 2" --source "Livro Y, p. 10" --tag "Básico" --tag "Equação"
+`,
+	Run: runAddQuestion,
 }
 
-// Struct to hold flag values
-var questionFlags struct {
-	Subject       string
-	Topic         string
-	Difficulty    string
-	QuestionType  string
-	QuestionText  string
-	AnswerOptions []string
+// Struct to hold flag values for the add command
+var addQuestionFlags struct {
+	Subject        string
+	Topic          string
+	Difficulty     string
+	QuestionType   string
+	QuestionText   string
+	AnswerOptions  []string
 	CorrectAnswers []string
-	Source        string
-	Tags          []string
-	Author        string
+	Source         string
+	Tags           []string
+	Author         string
 }
 
 func init() {
-	// fmt.Println("DEBUG: init() in cmd/bancoq/add.go called") // DEBUG line removed
 	BancoqCmd.AddCommand(bancoqAddCmd)
 
 	// Flags for non-interactive mode
-	bancoqAddCmd.Flags().StringVarP(&questionFlags.Subject, "subject", "s", "", "Disciplina da questão (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringVarP(&questionFlags.Topic, "topic", "t", "", "Tópico da questão (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringVarP(&questionFlags.Difficulty, "difficulty", "d", "", "Nível de dificuldade (easy, medium, hard) (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringVarP(&questionFlags.QuestionType, "type", "q", "", "Tipo da questão (multiple_choice, true_false, essay, short_answer) (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringVarP(&questionFlags.QuestionText, "question", "x", "", "Texto da questão (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringSliceVarP(&questionFlags.AnswerOptions, "option", "o", []string{}, "Opção de resposta (para multiple_choice, true_false). Pode ser usado múltiplas vezes")
-	bancoqAddCmd.Flags().StringSliceVarP(&questionFlags.CorrectAnswers, "answer", "a", []string{}, "Resposta(s) correta(s). Pode ser usado múltiplas vezes (obrigatório em modo não-interativo)")
-	bancoqAddCmd.Flags().StringVar(&questionFlags.Source, "source", "", "Fonte da questão (opcional)")
-	bancoqAddCmd.Flags().StringSliceVar(&questionFlags.Tags, "tag", []string{}, "Tag para a questão (opcional). Pode ser usado múltiplas vezes")
-	bancoqAddCmd.Flags().StringVar(&questionFlags.Author, "author", "", "Autor da questão (opcional)")
+	bancoqAddCmd.Flags().StringVarP(&addQuestionFlags.Subject, "subject", "s", "", "Disciplina da questão (obrigatório)")
+	bancoqAddCmd.Flags().StringVarP(&addQuestionFlags.Topic, "topic", "t", "", "Tópico da questão (obrigatório)")
+	bancoqAddCmd.Flags().StringVarP(&addQuestionFlags.Difficulty, "difficulty", "d", "", "Nível de dificuldade (easy, medium, hard) (obrigatório)")
+	bancoqAddCmd.Flags().StringVarP(&addQuestionFlags.QuestionType, "type", "q", "", "Tipo da questão (multiple_choice, true_false, essay, short_answer) (obrigatório)")
+	bancoqAddCmd.Flags().StringVarP(&addQuestionFlags.QuestionText, "question", "x", "", "Texto da questão (obrigatório)")
+	bancoqAddCmd.Flags().StringSliceVarP(&addQuestionFlags.AnswerOptions, "option", "o", []string{}, "Opção de resposta (para multiple_choice, true_false). Use múltiplas vezes para várias opções.")
+	bancoqAddCmd.Flags().StringSliceVarP(&addQuestionFlags.CorrectAnswers, "answer", "a", []string{}, "Resposta(s) correta(s). Use múltiplas vezes para várias respostas corretas (obrigatório).")
+	bancoqAddCmd.Flags().StringVar(&addQuestionFlags.Source, "source", "", "Fonte da questão (opcional)")
+	bancoqAddCmd.Flags().StringSliceVar(&addQuestionFlags.Tags, "tag", []string{}, "Tag para a questão (opcional). Use múltiplas vezes para várias tags.")
+	bancoqAddCmd.Flags().StringVar(&addQuestionFlags.Author, "author", "", "Autor da questão (opcional)")
+}
+
+// isValidDifficulty checks if the provided difficulty is valid.
+func isValidDifficulty(difficulty string) bool {
+	switch difficulty {
+	case models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard:
+		return true
+	default:
+		return false
+	}
+}
+
+// isValidQuestionType checks if the provided question type is valid.
+func isValidQuestionType(qType string) bool {
+	switch qType {
+	case models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer:
+		return true
+	default:
+		return false
+	}
 }
 
 func runAddQuestion(cmd *cobra.Command, args []string) {
-	// fmt.Println("DEBUG: runAddQuestion called") // DEBUG line removed
-	if err := db.InitDB(""); err != nil {
-		fmt.Fprintf(os.Stderr, "Erro ao inicializar o banco de dados: %v\n", err)
-		os.Exit(1)
+	// A inicialização do DB agora é feita no PersistentPreRunE do BancoqCmd
+
+	q := models.Question{
+		ID:        uuid.NewString(),
+		CreatedAt: time.Now(),
 	}
 
-	q := models.Question{}
-
-	// Determine mode: if any core flag is set, assume non-interactive
-	// Core flags: subject, topic, difficulty, type, question, answer
+	// Determine mode: if any core flag is explicitly set by the user, assume non-interactive.
+	// Core flags: subject, topic, difficulty, type, question, answer.
 	nonInteractive := cmd.Flags().Changed("subject") ||
 		cmd.Flags().Changed("topic") ||
 		cmd.Flags().Changed("difficulty") ||
 		cmd.Flags().Changed("type") ||
-		cmd.Flags().Changed("question") || // Using 'question' for questionText flag
+		cmd.Flags().Changed("question") ||
 		cmd.Flags().Changed("answer")
 
 	if nonInteractive {
-		// Non-interactive mode: Populate from flags
-		if questionFlags.Subject == "" || questionFlags.Topic == "" || questionFlags.Difficulty == "" || questionFlags.QuestionType == "" || questionFlags.QuestionText == "" || len(questionFlags.CorrectAnswers) == 0 {
-			fmt.Fprintln(os.Stderr, "Erro: No modo não-interativo, as flags --subject, --topic, --difficulty, --type, --question, e pelo menos uma --answer são obrigatórias.")
+		// --- Non-interactive mode: Populate from flags and validate ---
+		errorMessages := []string{}
+
+		if addQuestionFlags.Subject == "" {
+			errorMessages = append(errorMessages, "--subject é obrigatório.")
+		}
+		if addQuestionFlags.Topic == "" {
+			errorMessages = append(errorMessages, "--topic é obrigatório.")
+		}
+		if addQuestionFlags.Difficulty == "" {
+			errorMessages = append(errorMessages, "--difficulty é obrigatório.")
+		} else if !isValidDifficulty(addQuestionFlags.Difficulty) {
+			errorMessages = append(errorMessages, fmt.Sprintf("--difficulty inválido. Use um de: %s, %s, %s.", models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard))
+		}
+		if addQuestionFlags.QuestionType == "" {
+			errorMessages = append(errorMessages, "--type é obrigatório.")
+		} else if !isValidQuestionType(addQuestionFlags.QuestionType) {
+			errorMessages = append(errorMessages, fmt.Sprintf("--type inválido. Use um de: %s, %s, %s, %s.", models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer))
+		}
+		if addQuestionFlags.QuestionText == "" {
+			errorMessages = append(errorMessages, "--question é obrigatório.")
+		}
+		if len(addQuestionFlags.CorrectAnswers) == 0 {
+			errorMessages = append(errorMessages, "Pelo menos uma --answer é obrigatória.")
+		}
+
+		// Validate AnswerOptions based on QuestionType
+		if addQuestionFlags.QuestionType == models.QuestionTypeMultipleChoice || addQuestionFlags.QuestionType == models.QuestionTypeTrueFalse {
+			if len(addQuestionFlags.AnswerOptions) == 0 {
+				errorMessages = append(errorMessages, fmt.Sprintf("Para o tipo '%s', pelo menos uma --option é obrigatória.", addQuestionFlags.QuestionType))
+			}
+			// Ensure correct answers are among options for multiple choice
+			if addQuestionFlags.QuestionType == models.QuestionTypeMultipleChoice {
+				for _, ans := range addQuestionFlags.CorrectAnswers {
+					found := false
+					for _, opt := range addQuestionFlags.AnswerOptions {
+						if ans == opt {
+							found = true
+							break
+						}
+					}
+					if !found {
+						errorMessages = append(errorMessages, fmt.Sprintf("Resposta correta '%s' não está entre as opções fornecidas.", ans))
+					}
+				}
+			}
+		}
+
+
+		if len(errorMessages) > 0 {
+			fmt.Fprintln(os.Stderr, "Erro(s) ao adicionar questão no modo não-interativo:")
+			for _, msg := range errorMessages {
+				fmt.Fprintf(os.Stderr, "- %s\n", msg)
+			}
 			cmd.Help() // Show help
 			os.Exit(1)
 		}
-		q.Subject = questionFlags.Subject
-		q.Topic = questionFlags.Topic
-		q.Difficulty = questionFlags.Difficulty
-		q.QuestionType = questionFlags.QuestionType
-		q.QuestionText = questionFlags.QuestionText
-		q.AnswerOptions = questionFlags.AnswerOptions
-		q.CorrectAnswers = questionFlags.CorrectAnswers
-		q.Source = questionFlags.Source
-		q.Tags = questionFlags.Tags
-		q.Author = questionFlags.Author
+
+		q.Subject = addQuestionFlags.Subject
+		q.Topic = addQuestionFlags.Topic
+		q.Difficulty = addQuestionFlags.Difficulty
+		q.QuestionType = addQuestionFlags.QuestionType
+		q.QuestionText = addQuestionFlags.QuestionText
+		q.AnswerOptions = addQuestionFlags.AnswerOptions
+		q.CorrectAnswers = addQuestionFlags.CorrectAnswers
+		q.Source = addQuestionFlags.Source
+		q.Tags = addQuestionFlags.Tags
+		q.Author = addQuestionFlags.Author
+
 	} else {
-		// Interactive mode
+		// --- Interactive mode ---
 		fmt.Println("Adicionando nova questão (modo interativo)...")
 
-		// commonStringValidator := survey.WithValidator(survey.Required) // Removed as unused
-		// commonSliceValidator := survey.WithValidator(func(ans interface{}) error { // Removed as unused
-		// 	if sl, ok := ans.([]string); ok {
-		// 		if len(sl) == 0 {
-		// 			return fmt.Errorf("pelo menos uma resposta correta é necessária")
-		// 		}
-		// 	} else if str, ok := ans.(string); ok { // For single string inputs that become part of a slice
-		// 		if str == "" {
-		// 			return fmt.Errorf("este campo não pode ser vazio se você está adicionando um item")
-		// 		}
-		// 	}
-		// 	return nil
-		// })
-
 		prompts := []*survey.Question{
-			{
-				Name:   "Subject",
-				Prompt: &survey.Input{Message: "Disciplina:"},
-				Validate: survey.Required,
-			},
-			{
-				Name:   "Topic",
-				Prompt: &survey.Input{Message: "Tópico:"},
-				Validate: survey.Required,
-			},
+			{Name: "Subject", Prompt: &survey.Input{Message: "Disciplina:"}, Validate: survey.Required},
+			{Name: "Topic", Prompt: &survey.Input{Message: "Tópico:"}, Validate: survey.Required},
 			{
 				Name: "Difficulty",
 				Prompt: &survey.Select{
 					Message: "Nível de dificuldade:",
 					Options: []string{models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard},
-					Description: func(value string, index int) string {
-						switch value {
-						case models.DifficultyEasy: return "Fácil"
-						case models.DifficultyMedium: return "Médio"
-						case models.DifficultyHard: return "Difícil"
-						}
-						return value
-					},
+					Description: func(value string, index int) string { return models.FormatDifficultyToPtBR(value) },
 				},
 				Validate: survey.Required,
 			},
@@ -137,26 +183,17 @@ func runAddQuestion(cmd *cobra.Command, args []string) {
 				Prompt: &survey.Select{
 					Message: "Tipo da questão:",
 					Options: []string{models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer},
-					Description: func(value string, index int) string {
-						switch value {
-						case models.QuestionTypeMultipleChoice: return "Múltipla Escolha"
-						case models.QuestionTypeTrueFalse: return "Verdadeiro/Falso"
-						case models.QuestionTypeEssay: return "Dissertativa (Ensaio)"
-						case models.QuestionTypeShortAnswer: return "Resposta Curta"
-						}
-						return value
-					},
+					Description: func(value string, index int) string { return models.FormatQuestionTypeToPtBR(value) },
 				},
 				Validate: survey.Required,
 			},
 			{
-				Name:   "QuestionText",
-				Prompt: &survey.Editor{Message: "Texto da questão (use editor externo se preferir e cole aqui):", FileName: "nova_questao_*.md"},
+				Name:     "QuestionText",
+				Prompt:   &survey.Editor{Message: "Texto da questão (pressione Enter para abrir o editor):", FileName: "vickgenda_questao_*.md", HideDefault: true, AppendDefault: true},
 				Validate: survey.Required,
 			},
 		}
-		// Using a temporary struct for survey answermap
-		answers := struct {
+		answers := struct { // Temporary struct for survey answers
 			Subject      string
 			Topic        string
 			Difficulty   string
@@ -171,32 +208,51 @@ func runAddQuestion(cmd *cobra.Command, args []string) {
 		q.Topic = answers.Topic
 		q.Difficulty = answers.Difficulty
 		q.QuestionType = answers.QuestionType
-		q.QuestionText = answers.QuestionText
+		q.QuestionText = strings.TrimSpace(answers.QuestionText)
 
-		// Handle AnswerOptions (if multiple_choice or true_false)
+
 		if q.QuestionType == models.QuestionTypeMultipleChoice || q.QuestionType == models.QuestionTypeTrueFalse {
-			q.AnswerOptions = collectSliceItems("Opção de resposta (deixe vazio e pressione Enter para terminar):", "Adicionar outra opção de resposta?")
+			q.AnswerOptions = collectSliceItemsInteractively("Opção de resposta (deixe vazio e pressione Enter para terminar de adicionar opções):", "Adicionar outra opção de resposta?", false)
+			if len(q.AnswerOptions) == 0 {
+				fmt.Fprintf(os.Stderr, "Para o tipo '%s', pelo menos uma opção de resposta deve ser fornecida.\n", models.FormatQuestionTypeToPtBR(q.QuestionType))
+				os.Exit(1)
+			}
 		}
 
-		// Handle CorrectAnswers - always required
-		q.CorrectAnswers = collectSliceItems("Resposta correta (pelo menos uma é necessária; deixe vazio e pressione Enter para terminar após a primeira):", "Adicionar outra resposta correta?")
+		q.CorrectAnswers = collectSliceItemsInteractively("Resposta correta (deixe vazio e pressione Enter para terminar de adicionar respostas):", "Adicionar outra resposta correta?", true)
 		if len(q.CorrectAnswers) == 0 {
-		    // Re-ask if empty, as it's required.
-		    fmt.Println("Pelo menos uma resposta correta é obrigatória.")
-		    q.CorrectAnswers = collectSliceItems("Resposta correta (pelo menos uma é necessária; deixe vazio e pressione Enter para terminar após a primeira):", "Adicionar outra resposta correta?")
-		    if len(q.CorrectAnswers) == 0 {
-		         fmt.Fprintln(os.Stderr, "Erro: Pelo menos uma resposta correta deve ser fornecida.")
-		         os.Exit(1)
-		    }
+			fmt.Fprintln(os.Stderr, "Pelo menos uma resposta correta é obrigatória.")
+			os.Exit(1)
 		}
 
+        // Validate correct answers against options for multiple choice
+        if q.QuestionType == models.QuestionTypeMultipleChoice {
+            validAnswers := []string{}
+            for _, ans := range q.CorrectAnswers {
+                found := false
+                for _, opt := range q.AnswerOptions {
+                    if ans == opt {
+                        found = true
+                        break
+                    }
+                }
+                if !found {
+                    fmt.Fprintf(os.Stderr, "Atenção: A resposta correta '%s' não está entre as opções fornecidas. Por favor, adicione-a como uma opção ou corrija a resposta.\n", ans)
+                    // Re-collect options or answers, or simply error out
+                    // For simplicity, we'll error out here. More complex UX could allow correction.
+                    os.Exit(1)
+                }
+                validAnswers = append(validAnswers, ans)
+            }
+            q.CorrectAnswers = validAnswers
+        }
 
-		// Optional fields
+
 		optionalPrompts := []*survey.Question{
 			{Name: "Source", Prompt: &survey.Input{Message: "Fonte da questão (opcional):"}},
 			{Name: "Author", Prompt: &survey.Input{Message: "Autor da questão (opcional):"}},
 		}
-		optionalAnswers := struct {Source string; Author string}{}
+		optionalAnswers := struct{ Source, Author string }{}
 		if err := survey.Ask(optionalPrompts, &optionalAnswers); err != nil {
 			fmt.Fprintf(os.Stderr, "Erro no formulário interativo (opcionais): %v\n", err)
 			os.Exit(1)
@@ -204,20 +260,10 @@ func runAddQuestion(cmd *cobra.Command, args []string) {
 		q.Source = optionalAnswers.Source
 		q.Author = optionalAnswers.Author
 
-		q.Tags = collectSliceItems("Tag (opcional; deixe vazio e pressione Enter para terminar):", "Adicionar outra tag?")
+		q.Tags = collectSliceItemsInteractively("Tag (opcional; deixe vazio e pressione Enter para terminar de adicionar tags):", "Adicionar outra tag?", false)
 	}
 
 	// Finalize and save
-	if q.ID == "" { // Should always be empty unless future logic changes
-		q.ID = uuid.NewString()
-	}
-	if q.CreatedAt.IsZero() { // Should always be zero here
-		q.CreatedAt = time.Now()
-	}
-
-	// Ensure difficulty and type are stored in English, even if prompt showed Portuguese
-	// This is already handled by survey.Select if `Options` are the English constants.
-
 	newID, err := db.CreateQuestion(q)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Erro ao adicionar questão ao banco de dados: %v\n", err)
@@ -227,52 +273,38 @@ func runAddQuestion(cmd *cobra.Command, args []string) {
 	fmt.Printf("Questão adicionada com ID: %s\n", newID)
 }
 
-// Helper function to collect multiple string items for a slice field
-func collectSliceItems(initialMessage string, confirmMessage string) []string {
+// collectSliceItemsInteractively collects multiple string items for a slice field using survey.
+// `isRequired` means at least one item must be provided.
+func collectSliceItemsInteractively(initialMessage, confirmMessage string, isRequired bool) []string {
 	var items []string
 	for {
 		var item string
-		prompt := &survey.Input{Message: initialMessage}
-		if err := survey.AskOne(prompt, &item); err != nil {
+		itemPrompt := &survey.Input{Message: initialMessage}
+		if err := survey.AskOne(itemPrompt, &item); err != nil {
 			fmt.Fprintf(os.Stderr, "Erro ao coletar item: %v\n", err)
-			os.Exit(1) // or handle error more gracefully
+			os.Exit(1)
 		}
 
-		if strings.TrimSpace(item) == "" && len(items) > 0 { // Allow empty only if at least one item was added (for optional, or to finish)
+		item = strings.TrimSpace(item)
+		if item == "" {
+			if isRequired && len(items) == 0 {
+				fmt.Println("Este campo é obrigatório. Pelo menos um item deve ser adicionado.")
+				continue // Re-prompt for the first item
+			}
+			break // Empty input signals end of list for optional or if already has items
+		}
+
+		items = append(items, item)
+
+		var addMore bool
+		confirmPrompt := &survey.Confirm{Message: confirmMessage, Default: true}
+		if err := survey.AskOne(confirmPrompt, &addMore); err != nil {
+			fmt.Fprintf(os.Stderr, "Erro na confirmação: %v\n", err)
+			os.Exit(1)
+		}
+		if !addMore {
 			break
 		}
-		// Allow empty first entry to skip for optional fields or answer options (which can be empty e.g. for essay)
-		if strings.TrimSpace(item) == "" && len(items) == 0 && (strings.Contains(initialMessage, "opcional") || strings.Contains(initialMessage, "Opção de resposta")) {
-		    break
-		}
-		// Special handling for CorrectAnswers if first entry is empty - it's required.
-        if strings.TrimSpace(item) == "" && len(items) == 0 && strings.Contains(initialMessage, "Resposta correta") {
-            fmt.Println("Pelo menos uma resposta correta é necessária. Tente novamente.")
-            continue // Re-prompt for the first correct answer
-        }
-
-
-		if strings.TrimSpace(item) != "" {
-			items = append(items, strings.TrimSpace(item))
-		}
-
-		// Only ask to add another if the current item was not empty or if it's the first item for a required field (like CorrectAnswers).
-		if strings.TrimSpace(item) != "" || (len(items) == 1 && strings.Contains(initialMessage, "Resposta correta")) {
-			var addMore bool
-			confirmPrompt := &survey.Confirm{Message: confirmMessage, Default: true}
-			if err := survey.AskOne(confirmPrompt, &addMore); err != nil {
-				fmt.Fprintf(os.Stderr, "Erro na confirmação: %v\n", err)
-				os.Exit(1) // or handle error
-			}
-			if !addMore {
-				break
-			}
-		} else if strings.TrimSpace(item) == "" && len(items) == 0 && !strings.Contains(initialMessage, "opcional") && !strings.Contains(initialMessage, "Opção de resposta") {
-            // If a required field's first entry is empty (and not handled by specific logic above), break to avoid potential infinite loop.
-            // The main validation for required fields should ideally catch this before attempting to save.
-            break
-        }
-
 	}
 	return items
 }

--- a/cmd/bancoq/bancoq.go
+++ b/cmd/bancoq/bancoq.go
@@ -1,24 +1,36 @@
 package bancoq
 
 import (
-	// "fmt" // DEBUG - No longer needed here if init is removed
-	// "vickgenda-cli/cmd" // Removed to break import cycle
+	"fmt"
+	"os"
+
+	"vickgenda-cli/internal/db" // Importar o pacote db
+
 	"github.com/spf13/cobra"
 )
 
-// BancoqCmd represents the bancoq command
-// This will be added to rootCmd in cmd/root.go's init()
+// BancoqCmd representa o comando bancoq
 var BancoqCmd = &cobra.Command{
 	Use:   "bancoq",
 	Short: "Gerencia o banco de questões",
-	Long:  `O comando 'bancoq' é o ponto de entrada para todas as operações relacionadas ao banco de questões.
+	Long: `O comando 'bancoq' é o ponto de entrada para todas as operações relacionadas ao banco de questões.
 Ele permite adicionar, editar, excluir, listar, visualizar, buscar e importar questões.
-Utilize os subcomandos para realizar as ações específicas. Por exemplo, 'bancoq add' para adicionar uma nova questão.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("bancoq called, logic to be implemented.")
+Utilize os subcomandos para realizar as ações específicas. Por exemplo, 'vickgenda bancoq add' para adicionar uma nova questão.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Inicializa o banco de dados antes de qualquer subcomando de bancoq ser executado.
+		// Usar "" para o caminho fará com que InitDB use o caminho padrão.
+		if err := db.InitDB(""); err != nil {
+			// Imprimir o erro para stderr para que seja visível mesmo se o log não estiver configurado.
+			fmt.Fprintf(os.Stderr, "Erro crítico ao inicializar o banco de dados: %v\n", err)
+			// Retornar o erro fará com que o Cobra pare a execução do comando.
+			return fmt.Errorf("falha ao inicializar o banco de dados: %w", err)
+		}
 		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Se 'bancoq' for chamado sem subcomandos, mostrar ajuda.
+		return cmd.Help()
 	},
 }
 
-// init() is removed from here.
-// The BancoqCmd is added to rootCmd in cmd/root.go's init function.
+// A adição de BancoqCmd ao rootCmd é feita em cmd/root.go ou cmd/cli/cli.go

--- a/cmd/bancoq/edit.go
+++ b/cmd/bancoq/edit.go
@@ -13,94 +13,124 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
-	// "github.com/google/uuid" // Not needed, ID is not changed
 )
 
 var bancoqEditCmd = &cobra.Command{
 	Use:   "edit <ID_DA_QUESTAO>",
 	Short: "Edita uma questão existente no banco de dados",
-	Long:  `Permite editar interativamente os campos de uma questão existente, identificada pelo seu ID. Os valores atuais são apresentados e podem ser alterados.`,
-	Args:  cobra.ExactArgs(1),
-	Run:   runEditQuestion,
+	Long: `Permite editar interativamente os campos de uma questão existente,
+identificada pelo seu ID. Os valores atuais são apresentados e podem ser alterados.
+Para campos de texto simples, deixar o campo vazio e pressionar Enter manterá o valor atual.
+Para listas (opções, respostas, tags), a edição é mais interativa.`,
+	Args: cobra.ExactArgs(1),
+	Run:  runEditQuestion,
 }
 
 func init() {
 	BancoqCmd.AddCommand(bancoqEditCmd)
 }
 
-// Adapted from add.go - simplified for editing contexts
-func editCollectSliceItems(promptMessage string, fieldName string, currentItems []string) []string {
-	var items []string
-	fmt.Printf("Editando '%s'. Itens atuais: %s\n", fieldName, strings.Join(currentItems, ", "))
-	fmt.Println("Instruções: Digite um novo item e pressione Enter. Para remover o último item adicionado/existente, digite '-'. Para limpar todos os itens, digite '--clear'. Deixe vazio e pressione Enter para finalizar a adição/edição deste campo.")
+// editCollectSliceItemsInteractive provides a more user-friendly way to edit a slice of strings.
+// It starts with currentItems and allows adding, removing, or clearing.
+func editCollectSliceItemsInteractive(promptMessageSingular, fieldNameForMessages string, currentItems []string, required bool) []string {
+	items := make([]string, len(currentItems))
+	copy(items, currentItems)
 
+	fmt.Printf("\n--- Editando '%s' ---\n", fieldNameForMessages)
+	if len(items) > 0 {
+		fmt.Println("Itens atuais:")
+		for i, item := range items {
+			fmt.Printf("  %d: %s\n", i+1, item)
+		}
+	} else {
+		fmt.Println("Nenhum item atualmente.")
+	}
+	fmt.Println("Opções: [a]dicionar, [r]emover item pelo número, [c]lear todos, [f]inalizar edição deste campo.")
 
 	for {
-		var item string
-		// Ajustar a mensagem do prompt para ser mais clara no contexto de edição
-		itemPromptMessage := fmt.Sprintf("%s (atual: %d itens. '-' para remover, '--clear' para limpar, Enter para finalizar):", promptMessage, len(items))
-		if len(items) == 0 && len(currentItems) > 0 && items == nil { // Se 'items' ainda não foi populado, mas 'currentItems' existe
-			items = append(items, currentItems...) // Começar com os itens atuais para edição
-			fmt.Printf("Itens carregados para edição: %s. Prossiga para adicionar, remover ou finalizar.\n", strings.Join(items, ", "))
-			itemPromptMessage = fmt.Sprintf("%s (carregado: %d itens. '-' para remover, '--clear' para limpar, Enter para finalizar):", promptMessage, len(items))
+		var action string
+		actionPrompt := &survey.Input{Message: fmt.Sprintf("Ação para '%s' (a, r, c, f):", fieldNameForMessages)}
+		err := survey.AskOne(actionPrompt, &action)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Erro no prompt de ação: %v\n", err)
+			continue // Re-ask
 		}
+		action = strings.ToLower(strings.TrimSpace(action))
 
-
-		itemPrompt := &survey.Input{Message: itemPromptMessage}
-
-		if err := survey.AskOne(itemPrompt, &item); err != nil {
-			fmt.Fprintf(os.Stderr, "Erro ao coletar item para '%s': %v\n", fieldName, err)
-			os.Exit(1)
-		}
-
-		trimmedItem := strings.TrimSpace(item)
-
-		if trimmedItem == "" {
-			break // Finaliza a adição/edição para este campo
-		}
-		if trimmedItem == "--clear" {
-			items = []string{} // Limpa todos os itens
-			fmt.Println("Todos os itens foram removidos.")
-			// Considerar se deve continuar no loop para adicionar novos itens ou finalizar.
-			// Para consistência, finalizar aqui. O usuário pode re-editar se necessário.
-			break
-		}
-		if trimmedItem == "-" {
-			if len(items) > 0 {
-				removed := items[len(items)-1]
-				items = items[:len(items)-1]
-				fmt.Printf("Item '%s' removido. Itens restantes para '%s': %s\n", removed, fieldName, strings.Join(items, ", "))
-			} else {
-				fmt.Println("Nenhum item para remover.")
+		switch action {
+		case "a", "adicionar":
+			var newItem string
+			newItemPrompt := &survey.Input{Message: promptMessageSingular + ":"}
+			err := survey.AskOne(newItemPrompt, &newItem)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Erro ao adicionar novo item: %v\n", err)
+				continue
 			}
-			continue
+			trimmedNewItem := strings.TrimSpace(newItem)
+			if trimmedNewItem != "" {
+				items = append(items, trimmedNewItem)
+				fmt.Printf("Item '%s' adicionado.\n", trimmedNewItem)
+			} else {
+				fmt.Println("Nenhum item adicionado (entrada vazia).")
+			}
+		case "r", "remover":
+			if len(items) == 0 {
+				fmt.Println("Nenhum item para remover.")
+				continue
+			}
+			var itemNumberStr string
+			itemNumPrompt := &survey.Input{Message: fmt.Sprintf("Número do item a remover (1-%d):", len(items))}
+			err := survey.AskOne(itemNumPrompt, &itemNumberStr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Erro ao obter número do item: %v\n", err)
+				continue
+			}
+			itemNumber, convErr := survey.StdAsk.Atoi(itemNumberStr)
+			if convErr != nil || itemNumber < 1 || itemNumber > len(items) {
+				fmt.Println("Número inválido.")
+				continue
+			}
+			removedItem := items[itemNumber-1]
+			items = append(items[:itemNumber-1], items[itemNumber:]...)
+			fmt.Printf("Item '%s' removido.\n", removedItem)
+		case "c", "clear":
+			var confirmClear bool
+			confirmPrompt := &survey.Confirm{Message: fmt.Sprintf("Tem certeza que deseja remover TODOS os itens de '%s'?", fieldNameForMessages), Default: false}
+			survey.AskOne(confirmPrompt, &confirmClear)
+			if confirmClear {
+				items = []string{}
+				fmt.Println("Todos os itens foram removidos.")
+			}
+		case "f", "finalizar":
+			if required && len(items) == 0 {
+				fmt.Printf("'%s' é um campo obrigatório e não pode estar vazio. Por favor, adicione pelo menos um item ou cancele a edição (Ctrl+C).\n", fieldNameForMessages)
+				continue // Don't allow finalizing if required and empty
+			}
+			fmt.Printf("--- Finalizada a edição de '%s' ---\n", fieldNameForMessages)
+			return items
+		default:
+			fmt.Println("Ação inválida. Use 'a', 'r', 'c' ou 'f'.")
 		}
 
-		items = append(items, trimmedItem)
-		fmt.Printf("Item '%s' adicionado/mantido. Itens atuais para '%s': %s\n", trimmedItem, fieldName, strings.Join(items, ", "))
+		// Display current state after action
+		if len(items) > 0 {
+			fmt.Println("Itens atuais:")
+			for i, item := range items {
+				fmt.Printf("  %d: %s\n", i+1, item)
+			}
+		} else {
+			fmt.Println("Nenhum item atualmente.")
+		}
 	}
-
-	// Validação específica para campos obrigatórios como 'Respostas Corretas'
-	if fieldName == "Respostas Corretas" && len(items) == 0 {
-		fmt.Println("Atenção: O campo 'Respostas Corretas' não pode ficar vazio. Por favor, adicione pelo menos uma resposta.")
-		// Chama recursivamente para garantir que o usuário adicione pelo menos uma resposta.
-		// Passa um slice vazio como `currentItems` para evitar repopular com os antigos se o usuário limpou e tentou sair.
-		return editCollectSliceItems(promptMessage, fieldName, []string{})
-	}
-	return items
 }
 
-
 func runEditQuestion(cmd *cobra.Command, args []string) {
-	if err := db.InitDB(""); err != nil {
-		fmt.Fprintf(os.Stderr, "Erro ao inicializar o banco de dados: %v\n", err)
-		os.Exit(1)
-	}
+	// A inicialização do DB agora é feita no PersistentPreRunE do BancoqCmd
 
 	questionID := args[0]
 	q, err := db.GetQuestion(questionID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, sql.ErrNoRows) {
 			fmt.Fprintf(os.Stderr, "Erro: A questão com ID '%s' não foi encontrada.\n", questionID)
 		} else {
 			fmt.Fprintf(os.Stderr, "Erro ao buscar a questão com ID '%s': %v\n", questionID, err)
@@ -109,88 +139,96 @@ func runEditQuestion(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Printf("Editando questão com ID: %s (Deixe o campo em branco e pressione Enter para manter o valor atual, exceto para listas que têm manejo especial).\n\n", q.ID)
+	originalQuestionType := q.QuestionType // Store original type for logic later
 
-	// String fields
+	fmt.Printf("Editando questão com ID: %s\n", q.ID)
+	fmt.Println("(Deixe o campo em branco e pressione Enter para manter o valor atual para campos de texto simples)")
+	fmt.Println(strings.Repeat("-", 30))
+
+	// String fields (Subject, Topic)
 	survey.AskOne(&survey.Input{Message: "Disciplina:", Default: q.Subject}, &q.Subject, survey.WithValidator(survey.Required))
 	survey.AskOne(&survey.Input{Message: "Tópico:", Default: q.Topic}, &q.Topic, survey.WithValidator(survey.Required))
 
-	// Difficulty
-	difficultyOptions := []string{models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard}
-	difficultyDisplayMap := map[string]string{
-		models.DifficultyEasy:   models.FormatDifficultyToPtBR(models.DifficultyEasy),
-		models.DifficultyMedium: models.FormatDifficultyToPtBR(models.DifficultyMedium),
-		models.DifficultyHard:   models.FormatDifficultyToPtBR(models.DifficultyHard),
-	}
-	displayDifficultyOptions := make([]string, len(difficultyOptions))
-	for i, code := range difficultyOptions {
-		displayDifficultyOptions[i] = difficultyDisplayMap[code]
-	}
-	currentDifficultyDisplay := difficultyDisplayMap[q.Difficulty]
-	var selectedDifficultyDisplay string
-	survey.AskOne(&survey.Select{Message: "Nível de dificuldade:", Options: displayDifficultyOptions, Default: currentDifficultyDisplay}, &selectedDifficultyDisplay)
-	for code, display := range difficultyDisplayMap {
-		if display == selectedDifficultyDisplay {
-			q.Difficulty = code
-			break
+	// Difficulty (Select)
+	q.Difficulty = askSelect("Nível de dificuldade:", q.Difficulty,
+		[]string{models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard},
+		func(val string) string { return models.FormatDifficultyToPtBR(val) })
+
+	// QuestionType (Select)
+	q.QuestionType = askSelect("Tipo da questão:", q.QuestionType,
+		[]string{models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer},
+		func(val string) string { return models.FormatQuestionTypeToPtBR(val) })
+
+	// QuestionText (Editor)
+	newQuestionText := q.QuestionText
+	survey.AskOne(&survey.Editor{
+		Message:       "Texto da questão (pressione Enter para abrir o editor):",
+		Default:       q.QuestionText,
+		HideDefault:   true,
+		AppendDefault: true, // Loads default into editor
+		Help:          "O texto atual será carregado no editor. Ctrl+D para salvar, Esc para cancelar.",
+	}, &newQuestionText, survey.WithValidator(survey.Required))
+	q.QuestionText = strings.TrimSpace(newQuestionText)
+
+
+	// Slice fields: AnswerOptions, CorrectAnswers, Tags
+	// Only edit AnswerOptions if applicable to the NEW or ORIGINAL question type
+	isNowMcOrTf := q.QuestionType == models.QuestionTypeMultipleChoice || q.QuestionType == models.QuestionTypeTrueFalse
+	wasOriginallyMcOrTf := originalQuestionType == models.QuestionTypeMultipleChoice || originalQuestionType == models.QuestionTypeTrueFalse
+
+	if isNowMcOrTf || wasOriginallyMcOrTf { // If type is or was MC/TF, allow editing options
+		if confirmEditField(fmt.Sprintf("Opções de Resposta (atuais: %d)", len(q.AnswerOptions))) {
+			if isNowMcOrTf {
+				q.AnswerOptions = editCollectSliceItemsInteractive("Nova opção de resposta", "Opções de Resposta", q.AnswerOptions, true) // Required if type is MC/TF
+				if len(q.AnswerOptions) == 0 { // Double check, editCollect should handle 'required'
+					fmt.Fprintln(os.Stderr, "Erro: Opções de resposta são obrigatórias para este tipo de questão.")
+					os.Exit(1)
+				}
+			} else { // Type changed from MC/TF to something else
+				fmt.Println("Tipo da questão alterado, limpando opções de resposta.")
+				q.AnswerOptions = []string{}
+			}
 		}
+	} else { // Not MC/TF now and wasn't before
+		q.AnswerOptions = []string{} // Ensure it's empty
 	}
 
-	// QuestionType
-	typeOptions := []string{models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer}
-	typeDisplayMap := map[string]string{
-		models.QuestionTypeMultipleChoice: models.FormatQuestionTypeToPtBR(models.QuestionTypeMultipleChoice),
-		models.QuestionTypeTrueFalse:      models.FormatQuestionTypeToPtBR(models.QuestionTypeTrueFalse),
-		models.QuestionTypeEssay:          models.FormatQuestionTypeToPtBR(models.QuestionTypeEssay),
-		models.QuestionTypeShortAnswer:    models.FormatQuestionTypeToPtBR(models.QuestionTypeShortAnswer),
-	}
-	displayTypeOptions := make([]string, len(typeOptions))
-	for i, code := range typeOptions {
-		displayTypeOptions[i] = typeDisplayMap[code]
-	}
-	currentTypeDisplay := typeDisplayMap[q.QuestionType]
-	var selectedTypeDisplay string
-	survey.AskOne(&survey.Select{Message: "Tipo da questão:", Options: displayTypeOptions, Default: currentTypeDisplay}, &selectedTypeDisplay)
-	for code, display := range typeDisplayMap {
-		if display == selectedTypeDisplay {
-			q.QuestionType = code
-			break
-		}
-	}
 
-	// QuestionText
-	survey.AskOne(&survey.Editor{Message: "Texto da questão (pressione Enter para abrir o editor, Ctrl+D para salvar, Esc para cancelar):", Default: q.QuestionText, HideDefault: true, AppendDefault: true, Help: "Use Markdown para formatação se desejar. O texto atual será carregado no editor."}, &q.QuestionText, survey.WithValidator(survey.Required))
-
-
-	// Slice fields - using a confirm-then-re-enter approach
-	isMultipleChoiceType := q.QuestionType == models.QuestionTypeMultipleChoice || q.QuestionType == models.QuestionTypeTrueFalse
-	if confirmReEnter("Opções de Resposta", q.AnswerOptions, isMultipleChoiceType) {
-		if isMultipleChoiceType {
-			q.AnswerOptions = editCollectSliceItems("Nova opção de resposta", "Opções de Resposta", q.AnswerOptions)
-		} else {
-			fmt.Println("Opções de resposta não são aplicáveis para este tipo de questão e serão limpas.")
-			q.AnswerOptions = []string{}
-		}
-	}
-
-	// CorrectAnswers are always applicable and required
-	if confirmReEnter("Respostas Corretas", q.CorrectAnswers, true) { // true because it's always applicable/editable
-		q.CorrectAnswers = editCollectSliceItems("Nova resposta correta", "Respostas Corretas", q.CorrectAnswers)
-		if len(q.CorrectAnswers) == 0 {
-			fmt.Fprintln(os.Stderr, "Erro crítico: Pelo menos uma resposta correta deve ser fornecida. A edição não pode prosseguir sem isso.")
+	if confirmEditField(fmt.Sprintf("Respostas Corretas (atuais: %d)", len(q.CorrectAnswers))) {
+		q.CorrectAnswers = editCollectSliceItemsInteractive("Nova resposta correta", "Respostas Corretas", q.CorrectAnswers, true) // Always required
+		if len(q.CorrectAnswers) == 0 { // Double check
+			fmt.Fprintln(os.Stderr, "Erro: Pelo menos uma resposta correta é obrigatória.")
 			os.Exit(1)
 		}
 	}
-
-
-	if confirmReEnter("Tags", q.Tags, true) {
-		q.Tags = editCollectSliceItems("Nova tag", "Tags", q.Tags)
+	// Validate CorrectAnswers against AnswerOptions if multiple choice
+	if q.QuestionType == models.QuestionTypeMultipleChoice {
+		for _, ans := range q.CorrectAnswers {
+			found := false
+			for _, opt := range q.AnswerOptions {
+				if ans == opt {
+					found = true
+					break
+				}
+			}
+			if !found {
+				fmt.Fprintf(os.Stderr, "Erro: A resposta correta '%s' não está entre as opções de resposta fornecidas.\n", ans)
+				fmt.Println("Por favor, verifique as opções e respostas corretas.")
+				os.Exit(1)
+			}
+		}
 	}
 
-	// Optional string fields
+
+	if confirmEditField(fmt.Sprintf("Tags (atuais: %d)", len(q.Tags))) {
+		q.Tags = editCollectSliceItemsInteractive("Nova tag", "Tags", q.Tags, false) // Not required
+	}
+
+	// Optional string fields (Source, Author)
 	survey.AskOne(&survey.Input{Message: "Fonte (opcional):", Default: q.Source}, &q.Source)
 	survey.AskOne(&survey.Input{Message: "Autor (opcional):", Default: q.Author}, &q.Author)
 
+	// LastUsedAt is not typically edited by the user directly. CreatedAt is preserved.
 
 	err = db.UpdateQuestion(q)
 	if err != nil {
@@ -198,33 +236,46 @@ func runEditQuestion(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Questão com ID '%s' atualizada com sucesso.\n", questionID)
+	fmt.Printf("\nQuestão com ID '%s' atualizada com sucesso.\n", questionID)
 }
 
-// Helper function to confirm if user wants to edit a slice field
-func confirmReEnter(fieldName string, currentItems []string, applicable bool) bool {
-	if !applicable { // If the field is not applicable (e.g. AnswerOptions for Essay)
-		// fmt.Printf("Campo '%s' não aplicável para o tipo de questão atual.\n", fieldName) // Optional: user feedback
-		return false // Don't even ask to edit
-	}
-
-	currentValueDisplay := "(vazio)"
-	if len(currentItems) > 0 {
-		currentValueDisplay = strings.Join(currentItems, "; ")
-	}
-
-	message := fmt.Sprintf("O campo '%s' atualmente contém: [%s]. Deseja editar este campo?", fieldName, currentValueDisplay)
-
-	confirm := false
+// confirmEditField asks user if they want to edit a particular field.
+func confirmEditField(fieldNameWithCurrentState string) bool {
+	var confirm bool
 	prompt := &survey.Confirm{
-		Message: message,
+		Message: fmt.Sprintf("Deseja editar o campo: %s?", fieldNameWithCurrentState),
 		Default: false, // Default to not editing
-		Help:    fmt.Sprintf("Se escolher 'sim', você poderá adicionar, remover ou limpar os itens de '%s'. Se 'não', os itens atuais serão mantidos.", fieldName),
 	}
-	err := survey.AskOne(prompt, &confirm)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Erro no prompt de confirmação para '%s': %v. O campo não será editado.\n", fieldName, err)
-		return false // Default to not editing on error
-	}
+	survey.AskOne(prompt, &confirm)
 	return confirm
+}
+
+// askSelect is a helper for survey.Select, handling mapping between codes and display values.
+func askSelect(message, currentCodeValue string, codeOptions []string, formatFunc func(string) string) string {
+	displayOptions := make([]string, len(codeOptions))
+	displayToCodeMap := make(map[string]string)
+	var currentDisplayValue string
+
+	for i, code := range codeOptions {
+		display := formatFunc(code)
+		displayOptions[i] = display
+		displayToCodeMap[display] = code
+		if code == currentCodeValue {
+			currentDisplayValue = display
+		}
+	}
+
+	var selectedDisplayValue string
+	prompt := &survey.Select{
+		Message: message,
+		Options: displayOptions,
+		Default: currentDisplayValue, // survey.Select expects the Default to be one of the Options
+	}
+	survey.AskOne(prompt, &selectedDisplayValue)
+
+	// Map back to code, or return original if something went wrong (though survey should prevent invalid selection)
+	if code, ok := displayToCodeMap[selectedDisplayValue]; ok {
+		return code
+	}
+	return currentCodeValue // Fallback, should not happen with survey.Select
 }

--- a/cmd/bancoq/list.go
+++ b/cmd/bancoq/list.go
@@ -4,24 +4,23 @@ import (
 	"fmt"
 	"math"
 	"os"
-	// "strconv" // Removed as unused
 	"strings"
 
 	"vickgenda-cli/internal/db"
-	"vickgenda-cli/internal/models" // For potential use, though db returns models.Question
+	"vickgenda-cli/internal/models"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
-// Struct to hold list command flags
-var listFlags struct {
+// listCommandFlags holds flag values for the list command
+var listCommandFlags struct {
 	Subject    string
 	Topic      string
 	Difficulty string
 	Type       string
 	Author     string
-	Tags       []string // Changed from Tag (string slice) to Tags for clarity
+	Tags       []string
 	Limit      int
 	Page       int
 	SortBy     string
@@ -31,124 +30,148 @@ var listFlags struct {
 var bancoqListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lista as questões do banco de questões",
-	Long:  `Exibe uma lista paginada das questões armazenadas no banco de dados. Permite aplicar diversos filtros para refinar a busca e ordenar os resultados conforme especificado.`,
-	Run:   runListQuestions,
+	Long: `Exibe uma lista paginada das questões armazenadas no banco de dados.
+Permite aplicar diversos filtros para refinar a busca e ordenar os resultados.
+Exemplo:
+  vickgenda bancoq list --subject "História" --difficulty "medium" --limit 10 --page 2 --sort-by "topic" --order "asc"`,
+	Run: runListQuestions,
 }
 
 func init() {
 	BancoqCmd.AddCommand(bancoqListCmd)
 
 	// Filter flags
-	bancoqListCmd.Flags().StringVar(&listFlags.Subject, "subject", "", "Filtrar por disciplina (ex: \"Matemática\")")
-	bancoqListCmd.Flags().StringVar(&listFlags.Topic, "topic", "", "Filtrar por tópico (ex: \"Álgebra Linear\")")
-	bancoqListCmd.Flags().StringVar(&listFlags.Difficulty, "difficulty", "", "Filtrar por dificuldade (valores: easy, medium, hard)")
-	bancoqListCmd.Flags().StringVar(&listFlags.Type, "type", "", "Filtrar por tipo de questão (valores: multiple_choice, true_false, essay, short_answer)")
-	bancoqListCmd.Flags().StringVar(&listFlags.Author, "author", "", "Filtrar por autor da questão")
-	bancoqListCmd.Flags().StringSliceVar(&listFlags.Tags, "tag", []string{}, "Filtrar por tag (pode ser usado múltiplas vezes para buscar questões com qualquer uma das tags)")
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Subject, "subject", "", "Filtrar por disciplina (ex: \"Matemática\")")
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Topic, "topic", "", "Filtrar por tópico (ex: \"Álgebra Linear\")")
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Difficulty, "difficulty", "", fmt.Sprintf("Filtrar por dificuldade (valores: %s, %s, %s)", models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard))
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Type, "type", "", fmt.Sprintf("Filtrar por tipo de questão (valores: %s, %s, %s, %s)", models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer))
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Author, "author", "", "Filtrar por autor da questão")
+	bancoqListCmd.Flags().StringSliceVar(&listCommandFlags.Tags, "tag", []string{}, "Filtrar por tag (atualmente considera apenas a primeira tag fornecida).")
 
 	// Pagination flags
-	bancoqListCmd.Flags().IntVar(&listFlags.Limit, "limit", 20, "Número de questões a serem exibidas por página")
-	bancoqListCmd.Flags().IntVar(&listFlags.Page, "page", 1, "Número da página a ser visualizada")
+	bancoqListCmd.Flags().IntVar(&listCommandFlags.Limit, "limit", 20, "Número de questões a serem exibidas por página")
+	bancoqListCmd.Flags().IntVar(&listCommandFlags.Page, "page", 1, "Número da página a ser visualizada")
 
 	// Sort flags
-	bancoqListCmd.Flags().StringVar(&listFlags.SortBy, "sort-by", "created_at", "Coluna para ordenação (opções: id, subject, topic, difficulty, question_type, created_at, last_used_at, author)")
-	bancoqListCmd.Flags().StringVar(&listFlags.Order, "order", "desc", "Ordem da ordenação (valores: asc, desc)")
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.SortBy, "sort-by", "created_at", "Coluna para ordenação (opções: id, subject, topic, difficulty, question_type, created_at, last_used_at, author)")
+	bancoqListCmd.Flags().StringVar(&listCommandFlags.Order, "order", "desc", "Ordem da ordenação (valores: asc, desc)")
 }
 
+// isValidDifficulty checks if the provided difficulty is valid.
+func isValidListDifficulty(difficulty string) bool {
+	if difficulty == "" { // Allow empty for no filter
+		return true
+	}
+	switch difficulty {
+	case models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard:
+		return true
+	default:
+		return false
+	}
+}
+
+// isValidListQuestionType checks if the provided question type is valid.
+func isValidListQuestionType(qType string) bool {
+	if qType == "" { // Allow empty for no filter
+		return true
+	}
+	switch qType {
+	case models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer:
+		return true
+	default:
+		return false
+	}
+}
+
+
 func runListQuestions(cmd *cobra.Command, args []string) {
-	if err := db.InitDB(""); err != nil { // Ensure DB is initialized
-		fmt.Fprintf(os.Stderr, "Erro ao inicializar o banco de dados: %v\n", err)
+	// A inicialização do DB agora é feita no PersistentPreRunE do BancoqCmd
+
+	// Validate flag values
+	if !isValidListDifficulty(listCommandFlags.Difficulty) {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --difficulty: '%s'. Use '%s', '%s' ou '%s'.\n", listCommandFlags.Difficulty, models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard)
 		os.Exit(1)
 	}
+	if !isValidListQuestionType(listCommandFlags.Type) {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --type: '%s'. Use '%s', '%s', '%s' ou '%s'.\n", listCommandFlags.Type, models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer)
+		os.Exit(1)
+	}
+	order := strings.ToLower(listCommandFlags.Order)
+	if order != "asc" && order != "desc" {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --order: '%s'. Use 'asc' ou 'desc'.\n", listCommandFlags.Order)
+		os.Exit(1)
+	}
+	// Note: SortBy validation is primarily handled by db.ListQuestions to keep it centralized with DB column names.
 
 	filters := make(map[string]interface{})
-	if listFlags.Subject != "" {
-		filters["subject"] = listFlags.Subject
+	if listCommandFlags.Subject != "" {
+		filters["subject"] = listCommandFlags.Subject
 	}
-	if listFlags.Topic != "" {
-		filters["topic"] = listFlags.Topic
+	if listCommandFlags.Topic != "" {
+		filters["topic"] = listCommandFlags.Topic
 	}
-	if listFlags.Difficulty != "" {
-		// TODO: Validar valor de dificuldade contra models.DifficultyEasy, etc.
-		filters["difficulty"] = listFlags.Difficulty
+	if listCommandFlags.Difficulty != "" {
+		filters["difficulty"] = listCommandFlags.Difficulty
 	}
-	if listFlags.Type != "" {
-		// TODO: Validar valor de tipo contra models.QuestionTypeMultipleChoice, etc.
-		filters["question_type"] = listFlags.Type // Campo no BD é question_type
+	if listCommandFlags.Type != "" {
+		filters["question_type"] = listCommandFlags.Type // DB field is question_type
 	}
-	if listFlags.Author != "" {
-		filters["author"] = listFlags.Author
+	if listCommandFlags.Author != "" {
+		filters["author"] = listCommandFlags.Author
 	}
-	if len(listFlags.Tags) > 0 {
-		// db.ListQuestions espera uma string única para tags se for uma busca LIKE simples.
-		// Se db.ListQuestions for melhorado para tratar múltiplas tags (ex: AND ou OR), isto pode mudar.
-		// Por enquanto, se múltiplas --tag flags são usadas, podemos juntá-las ou usar apenas a primeira.
-		// A query atual `tags LIKE ?` implica busca por substring.
-		// Então, se múltiplas tags são providas, usaremos apenas a primeira por agora.
-		// Esta parte de db.ListQuestions pode precisar de melhoria para filtragem multi-tag.
-		filters["tags"] = listFlags.Tags[0] // Passa apenas a primeira tag por enquanto.
+	if len(listCommandFlags.Tags) > 0 {
+		// CURRENT LIMITATION: db.ListQuestions currently supports filtering by a single tag string (LIKE %tag%).
+		// For true multi-tag (OR/AND) functionality, db.ListQuestions would need modification.
+		// For now, we'll use the first tag provided, or join them if the backend supported it differently.
+		filters["tags"] = listCommandFlags.Tags[0]
+		if len(listCommandFlags.Tags) > 1 {
+			fmt.Fprintln(os.Stdout, "Aviso: Múltiplas tags foram fornecidas. Atualmente, a filtragem considera apenas a primeira tag:", listCommandFlags.Tags[0])
+		}
 	}
 
-	// Validate sort order
-	order := strings.ToLower(listFlags.Order)
-	if order != "asc" && order != "desc" {
-		fmt.Fprintf(os.Stderr, "Valor inválido para --order: '%s'. Use 'asc' ou 'desc'.\n", listFlags.Order)
-		os.Exit(1)
-	}
 
-	// Basic validation for sort-by column (already handled more robustly in db.ListQuestions)
-	// We can add a similar client-side check if desired.
-
-	questions, total, err := db.ListQuestions(filters, listFlags.SortBy, order, listFlags.Limit, listFlags.Page)
+	questions, total, err := db.ListQuestions(filters, listCommandFlags.SortBy, order, listCommandFlags.Limit, listCommandFlags.Page)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Erro ao listar as questões: %v\n", err)
 		os.Exit(1)
 	}
 
-	if len(questions) == 0 {
+	if total == 0 { // Check total count first
 		fmt.Println("Nenhuma questão foi encontrada com os filtros aplicados.")
-		if total > 0 { // This case implies current page has no items but others might
-			totalPages := int(math.Ceil(float64(total) / float64(listFlags.Limit)))
-			fmt.Printf("Total de questões no banco que correspondem aos filtros (fora da paginação atual): %d. Total de páginas: %d.\n", total, totalPages)
-		}
+		return
+	}
+	if len(questions) == 0 && listCommandFlags.Page > 1 { // If not on page 1 and no results for this page
+		totalPages := int(math.Ceil(float64(total) / float64(listCommandFlags.Limit)))
+		fmt.Printf("Nenhuma questão encontrada na página %d. Total de páginas: %d.\n", listCommandFlags.Page, totalPages)
+		fmt.Printf("Total de questões no banco que correspondem aos filtros: %d.\n", total)
 		return
 	}
 
+
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "Disciplina", "Tópico", "Tipo", "Dificuldade", "Início da Questão"}) // Mantidos em Português conforme arquivo
+	table.SetHeader([]string{"ID Curto", "Disciplina", "Tópico", "Tipo", "Dificuldade", "Início da Questão"})
 	table.SetBorder(true)
 	table.SetRowLine(true)
+	table.SetColWidth(60) // Set a reasonable overall column width for QuestionText preview
+    table.SetAutoWrapText(false) // Prevent auto-wrapping that might break table structure with long text
 
 	for _, q := range questions {
 		idShort := q.ID
-		if len(q.ID) > 8 { // Limitar tamanho do ID exibido para não quebrar a tabela
-			idShort = q.ID[:8] + "..."
+		if len(q.ID) > 12 {
+			idShort = q.ID[:12] + "..."
 		}
 
-		questionTextShort := strings.ReplaceAll(q.QuestionText, "\n", " ")
-		if len(questionTextShort) > 50 { // Limitar tamanho do texto da questão exibido
-			runes := []rune(questionTextShort) // Lidar com caracteres multi-byte
-			if len(runes) > 50 {
-				questionTextShort = string(runes[:47]) + "..."
+		questionTextPreview := strings.ReplaceAll(q.QuestionText, "\n", " ") // Replace newlines for single line preview
+		maxPreviewLength := 47 // Max length for the preview text itself
+		if len(questionTextPreview) > maxPreviewLength {
+			runes := []rune(questionTextPreview)
+			if len(runes) > maxPreviewLength {
+				questionTextPreview = string(runes[:maxPreviewLength-3]) + "..."
 			} else {
-				questionTextShort = string(runes)
+				// This case should not be hit if len(questionTextPreview) > maxPreviewLength
+				// but as a fallback, use the full string if rune conversion results in shorter.
+				questionTextPreview = string(runes)
 			}
-		}
-
-		// A tradução para exibição já é feita no original, mantendo.
-		displayDifficulty := q.Difficulty
-		switch q.Difficulty {
-		case models.DifficultyEasy: displayDifficulty = "Fácil"
-		case models.DifficultyMedium: displayDifficulty = "Médio"
-		case models.DifficultyHard: displayDifficulty = "Difícil"
-		}
-
-		displayType := q.QuestionType
-		switch q.QuestionType {
-		case models.QuestionTypeMultipleChoice: displayType = "Múltipla Escolha"
-		case models.QuestionTypeTrueFalse: displayType = "Verdadeiro/Falso"
-		case models.QuestionTypeEssay: displayType = "Dissertativa"
-		case models.QuestionTypeShortAnswer: displayType = "Resposta Curta"
 		}
 
 
@@ -156,20 +179,19 @@ func runListQuestions(cmd *cobra.Command, args []string) {
 			idShort,
 			q.Subject,
 			q.Topic,
-			displayType,
-			displayDifficulty,
-			questionTextShort,
+			models.FormatQuestionTypeToPtBR(q.QuestionType),
+			models.FormatDifficultyToPtBR(q.Difficulty),
+			questionTextPreview,
 		}
 		table.Append(row)
 	}
 	table.Render()
 
-	totalPages := 0
-	if listFlags.Limit > 0 { // Evitar divisão por zero se limit for 0 ou negativo
-		totalPages = int(math.Ceil(float64(total) / float64(listFlags.Limit)))
-	} else if total > 0 { // Se limit não é positivo mas há itens, considerar como 1 página gigante
-		totalPages = 1
+	totalPages := 1 // Default to 1 page if limit is 0 or less, or if total is less than limit
+	if listCommandFlags.Limit > 0 && total > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(listCommandFlags.Limit)))
 	}
 
-	fmt.Printf("\nPágina %d de %d. Total de questões correspondentes aos filtros: %d.\n", listFlags.Page, totalPages, total)
+
+	fmt.Printf("\nPágina %d de %d. Total de questões correspondentes aos filtros: %d.\n", listCommandFlags.Page, totalPages, total)
 }

--- a/cmd/bancoq/search.go
+++ b/cmd/bancoq/search.go
@@ -13,27 +13,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var searchFlags struct {
+// searchCommandFlags holds flag values specifically for the search command.
+// It mirrors listCommandFlags for consistency in filtering, pagination, and sorting.
+var searchCommandFlags struct {
 	Subject      string
 	Topic        string
 	Difficulty   string
 	Type         string
 	Author       string
-	Tags         []string // For --tag filter
+	Tags         []string
 	Limit        int
 	Page         int
 	SortBy       string
 	Order        string
-	SearchFields []string // For --field flag
+	SearchFields []string // Specific to search: fields to search within
 }
 
 var bancoqSearchCmd = &cobra.Command{
 	Use:   "search <TERMO_DE_BUSCA>",
 	Short: "Busca questões por palavras-chave no banco de dados",
 	Long: `Realiza uma busca textual por questões no banco de dados utilizando as palavras-chave fornecidas.
-Por padrão, a busca é realizada nos campos de texto principais da questão (texto, disciplina, tópico).
-Utilize a flag --field para especificar outros campos ou 'all' para todos os campos textuais indexados.
-Filtros adicionais por disciplina, tópico, dificuldade, etc., podem ser aplicados.`,
+A busca pode ser direcionada a campos específicos usando a flag --field.
+Filtros adicionais (disciplina, tópico, etc.) podem ser combinados com o termo de busca.
+Exemplo:
+  vickgenda bancoq search "teorema de pitágoras" --subject "Matemática" --field "question_text" --field "topic"`,
 	Args: cobra.ExactArgs(1), // Requer exatamente um argumento para o termo de busca
 	Run:  runSearchQuestions,
 }
@@ -41,31 +44,39 @@ Filtros adicionais por disciplina, tópico, dificuldade, etc., podem ser aplicad
 func init() {
 	BancoqCmd.AddCommand(bancoqSearchCmd)
 
-	// Standard filter flags (same as list)
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Subject, "subject", "", "Filtrar por disciplina (ex: \"Matemática\")")
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Topic, "topic", "", "Filtrar por tópico (ex: \"Álgebra Linear\")")
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Difficulty, "difficulty", "", "Filtrar por dificuldade (valores: easy, medium, hard)")
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Type, "type", "", "Filtrar por tipo de questão (valores: multiple_choice, true_false, essay, short_answer)")
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Author, "author", "", "Filtrar por autor da questão")
-	bancoqSearchCmd.Flags().StringSliceVar(&searchFlags.Tags, "tag", []string{}, "Filtrar por tag específica (correspondência exata na lista de tags da questão; pode ser usado múltiplas vezes)")
+	// Standard filter flags (mirrors list.go for consistency)
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Subject, "subject", "", "Filtrar por disciplina")
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Topic, "topic", "", "Filtrar por tópico")
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Difficulty, "difficulty", "", fmt.Sprintf("Filtrar por dificuldade (%s, %s, %s)", models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard))
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Type, "type", "", fmt.Sprintf("Filtrar por tipo (%s, %s, %s, %s)", models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer))
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Author, "author", "", "Filtrar por autor")
+	bancoqSearchCmd.Flags().StringSliceVar(&searchCommandFlags.Tags, "tag", []string{}, "Filtrar por tag (atualmente considera apenas a primeira tag fornecida)")
 
 	// Pagination flags
-	bancoqSearchCmd.Flags().IntVar(&searchFlags.Limit, "limit", 20, "Número de questões a serem exibidas por página")
-	bancoqSearchCmd.Flags().IntVar(&searchFlags.Page, "page", 1, "Número da página a ser visualizada")
+	bancoqSearchCmd.Flags().IntVar(&searchCommandFlags.Limit, "limit", 20, "Número de questões por página")
+	bancoqSearchCmd.Flags().IntVar(&searchCommandFlags.Page, "page", 1, "Número da página")
 
 	// Sort flags
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.SortBy, "sort-by", "created_at", "Coluna para ordenação (padrão: created_at; 'relevance' pode ser suportado futuramente com FTS)")
-	bancoqSearchCmd.Flags().StringVar(&searchFlags.Order, "order", "desc", "Ordem da ordenação (valores: asc, desc)")
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.SortBy, "sort-by", "created_at", "Coluna para ordenação (padrão: created_at)") // 'relevance' could be added if FTS is implemented
+	bancoqSearchCmd.Flags().StringVar(&searchCommandFlags.Order, "order", "desc", "Ordem (asc, desc)")
 
 	// Search specific flag
-	bancoqSearchCmd.Flags().StringSliceVar(&searchFlags.SearchFields, "field", []string{"question_text", "subject", "topic"}, "Campos para realizar a busca textual (ex: question_text, subject, topic, tags, source, author, all)")
+	bancoqSearchCmd.Flags().StringSliceVar(&searchCommandFlags.SearchFields, "field", []string{"question_text", "subject", "topic"}, "Campos para busca textual (ex: question_text, subject, topic, tags, all)")
 }
 
+// isValidSearchDifficulty - wrapper for list's validator, allows empty
+func isValidSearchDifficulty(difficulty string) bool {
+	return isValidListDifficulty(difficulty) // from list.go (or a common validator package)
+}
+
+// isValidSearchQuestionType - wrapper for list's validator, allows empty
+func isValidSearchQuestionType(qType string) bool {
+	return isValidListQuestionType(qType) // from list.go (or a common validator package)
+}
+
+
 func runSearchQuestions(cmd *cobra.Command, args []string) {
-	if err := db.InitDB(""); err != nil {
-		fmt.Fprintf(os.Stderr, "Erro ao inicializar o banco de dados: %v\n", err)
-		os.Exit(1)
-	}
+	// A inicialização do DB agora é feita no PersistentPreRunE do BancoqCmd
 
 	searchQuery := args[0]
 	if strings.TrimSpace(searchQuery) == "" {
@@ -73,30 +84,45 @@ func runSearchQuestions(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Validate flags
+	if !isValidSearchDifficulty(searchCommandFlags.Difficulty) {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --difficulty: '%s'. Use '%s', '%s' ou '%s'.\n", searchCommandFlags.Difficulty, models.DifficultyEasy, models.DifficultyMedium, models.DifficultyHard)
+		os.Exit(1)
+	}
+	if !isValidSearchQuestionType(searchCommandFlags.Type) {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --type: '%s'. Use '%s', '%s', '%s' ou '%s'.\n", searchCommandFlags.Type, models.QuestionTypeMultipleChoice, models.QuestionTypeTrueFalse, models.QuestionTypeEssay, models.QuestionTypeShortAnswer)
+		os.Exit(1)
+	}
+	order := strings.ToLower(searchCommandFlags.Order)
+	if order != "asc" && order != "desc" {
+		fmt.Fprintf(os.Stderr, "Valor inválido para --order: '%s'. Use 'asc' ou 'desc'.\n", searchCommandFlags.Order)
+		os.Exit(1)
+	}
+
+
 	filters := make(map[string]interface{})
 
 	// Standard filters
-	if searchFlags.Subject != "" {
-		filters["subject"] = searchFlags.Subject
+	if searchCommandFlags.Subject != "" {
+		filters["subject"] = searchCommandFlags.Subject
 	}
-	if searchFlags.Topic != "" {
-		filters["topic"] = searchFlags.Topic
+	if searchCommandFlags.Topic != "" {
+		filters["topic"] = searchCommandFlags.Topic
 	}
-	if searchFlags.Difficulty != "" {
-		filters["difficulty"] = searchFlags.Difficulty
+	if searchCommandFlags.Difficulty != "" {
+		filters["difficulty"] = searchCommandFlags.Difficulty
 	}
-	if searchFlags.Type != "" {
-		filters["question_type"] = searchFlags.Type // DB field is question_type
+	if searchCommandFlags.Type != "" {
+		filters["question_type"] = searchCommandFlags.Type
 	}
-	if searchFlags.Author != "" {
-		filters["author"] = searchFlags.Author
+	if searchCommandFlags.Author != "" {
+		filters["author"] = searchCommandFlags.Author
 	}
-	if len(searchFlags.Tags) > 0 {
-		// The `db.ListQuestions` handles `filters["tags"]` with a LIKE clause: `tags LIKE %tagValue%`
-		// If multiple --tag flags are provided, we might want to pass them all and let db layer decide how to combine (e.g. AND or OR)
-		// For now, consistent with `list`, we'll pass the first one if that's how db.ListQuestions handles it.
-		// The current db.ListQuestions implementation for `case "tags":` uses `"%"+valStr+"%"` which means it expects a single string.
-		filters["tags"] = searchFlags.Tags[0]
+	if len(searchCommandFlags.Tags) > 0 {
+		filters["tags"] = searchCommandFlags.Tags[0] // Consistent with list.go, uses first tag
+		if len(searchCommandFlags.Tags) > 1 {
+			fmt.Fprintln(os.Stdout, "Aviso: Múltiplas tags foram fornecidas. Atualmente, a filtragem considera apenas a primeira tag:", searchCommandFlags.Tags[0])
+		}
 	}
 
 	// Search specific filters
@@ -104,65 +130,63 @@ func runSearchQuestions(cmd *cobra.Command, args []string) {
 
 	processedSearchFields := []string{}
 	userProvidedAll := false
-	for _, f := range searchFlags.SearchFields {
+	for _, f := range searchCommandFlags.SearchFields {
 		if strings.ToLower(f) == "all" {
 			userProvidedAll = true
 			break
 		}
-		// Basic validation for field names (can correspond to db.ListQuestions's validSearchFields)
-		// For simplicity, we trust user input here or rely on db.ListQuestions's own validation.
 		processedSearchFields = append(processedSearchFields, strings.ToLower(f))
 	}
 
 	if userProvidedAll {
-		filters["search_fields"] = []string{"question_text", "subject", "topic", "tags", "source", "author"} // Default "all" fields
+		// These are the fields db.ListQuestions knows how to search if "search_fields" contains them.
+		filters["search_fields"] = []string{"id", "subject", "topic", "question_text", "source", "tags", "author", "difficulty", "question_type"}
 	} else if len(processedSearchFields) > 0 {
 		filters["search_fields"] = processedSearchFields
 	} else {
-		// Default if --field is not used or is empty after processing (though cobra default helps)
+		// Default if --field is not used or is empty, cobra default should handle this, but as a safeguard:
 		filters["search_fields"] = []string{"question_text", "subject", "topic"}
 	}
 
-
-	order := strings.ToLower(searchFlags.Order)
-	if order != "asc" && order != "desc" {
-		fmt.Fprintf(os.Stderr, "Valor inválido para --order: '%s'. Use 'asc' ou 'desc'.\n", searchFlags.Order)
-		os.Exit(1)
-	}
-
-	questions, total, err := db.ListQuestions(filters, searchFlags.SortBy, order, searchFlags.Limit, searchFlags.Page)
+	questions, total, err := db.ListQuestions(filters, searchCommandFlags.SortBy, order, searchCommandFlags.Limit, searchCommandFlags.Page)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Erro ao buscar questões: %v\n", err)
 		os.Exit(1)
 	}
 
-	if len(questions) == 0 {
+	if total == 0 {
 		fmt.Println("Nenhuma questão foi encontrada para o termo de busca e filtros aplicados.")
-		if total > 0 {
-			totalPages := int(math.Ceil(float64(total) / float64(searchFlags.Limit)))
-			fmt.Printf("Total de questões no banco que correspondem aos filtros (antes da busca por termo): %d. Total de páginas: %d.\n", total, totalPages)
-		}
 		return
 	}
+    if len(questions) == 0 && searchCommandFlags.Page > 1 {
+        totalPages := int(math.Ceil(float64(total) / float64(searchCommandFlags.Limit)))
+		fmt.Printf("Nenhuma questão encontrada na página %d. Total de páginas: %d.\n", searchCommandFlags.Page, totalPages)
+		fmt.Printf("Total de questões no banco que correspondem aos filtros e termo de busca: %d.\n", total)
+		return
+    }
+
 
 	table := tablewriter.NewWriter(os.Stdout)
-	// Table headers are already in Portuguese.
-	table.SetHeader([]string{"ID", "Matéria", "Tópico", "Tipo", "Dificuldade", "Início da Questão"})
+	table.SetHeader([]string{"ID Curto", "Disciplina", "Tópico", "Tipo", "Dificuldade", "Início da Questão"})
 	table.SetBorder(true)
 	table.SetRowLine(true)
+    table.SetColWidth(60)
+    table.SetAutoWrapText(false)
+
 
 	for _, q := range questions {
 		idShort := q.ID
-		if len(q.ID) > 8 { // Limitar ID para exibição
-			idShort = q.ID[:8] + "..."
+		if len(q.ID) > 12 {
+			idShort = q.ID[:12] + "..."
 		}
-		questionTextShort := strings.ReplaceAll(q.QuestionText, "\n", " ")
-		if len(questionTextShort) > 50 { // Limitar texto para exibição
-			runes := []rune(questionTextShort) // Lidar com caracteres multi-byte
-			if len(runes) > 50 {
-				questionTextShort = string(runes[:47]) + "..."
+		questionTextPreview := strings.ReplaceAll(q.QuestionText, "\n", " ")
+		maxPreviewLength := 47
+		if len(questionTextPreview) > maxPreviewLength {
+			runes := []rune(questionTextPreview)
+			if len(runes) > maxPreviewLength {
+				questionTextPreview = string(runes[:maxPreviewLength-3]) + "..."
 			} else {
-				questionTextShort = string(runes)
+				questionTextPreview = string(runes)
 			}
 		}
 		row := []string{
@@ -171,17 +195,15 @@ func runSearchQuestions(cmd *cobra.Command, args []string) {
 			q.Topic,
 			models.FormatQuestionTypeToPtBR(q.QuestionType),
 			models.FormatDifficultyToPtBR(q.Difficulty),
-			questionTextShort,
+			questionTextPreview,
 		}
 		table.Append(row)
 	}
 	table.Render()
 
-	totalPages := 0
-	if searchFlags.Limit > 0 { // Evitar divisão por zero
-		totalPages = int(math.Ceil(float64(total) / float64(searchFlags.Limit)))
-	} else if total > 0 { // Se limite não for positivo mas houver itens, considerar 1 página
-		totalPages = 1
+	totalPages := 1
+	if searchCommandFlags.Limit > 0 && total > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(searchCommandFlags.Limit)))
 	}
-	fmt.Printf("\nPágina %d de %d. Total de questões correspondentes aos filtros e termo de busca: %d.\n", searchFlags.Page, totalPages, total)
+	fmt.Printf("\nPágina %d de %d. Total de questões correspondentes aos filtros e termo de busca: %d.\n", searchCommandFlags.Page, totalPages, total)
 }


### PR DESCRIPTION
Funcionalidades implementadas:
- Adiciona os subcomandos `add`, `list`, `view`, `edit`, `delete`, `import` e `search` para o `bancoq`.
- `add`: Permite adicionar questões interativamente ou via flags, com validações.
- `list`: Lista questões com filtros, paginação e ordenação.
- `view`: Exibe detalhes completos de uma questão.
- `edit`: Permite edição interativa de questões existentes.
- `delete`: Remove questões com confirmação ou flag `--force`.
- `import`: Importa questões de arquivo JSON, com políticas de conflito e dry-run.
- `search`: Busca textual em questões com filtros.
- Interação completa com as funções CRUD do banco de dados para o modelo `Question`.
- Centralização da inicialização do banco de dados no `PersistentPreRunE` do `BancoqCmd`.
- Revisão de mensagens ao usuário para pt-BR e documentação de ajuda dos comandos.